### PR TITLE
fix(s3): R2 Copy compatibility + Remove sync checks

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -96,6 +96,7 @@ func New(ctx context.Context, log logrus.FieldLogger, config *Config) (*agent, e
 	}, nil
 }
 
+//nolint:gocyclo // this is a complex function but most of it is event callbacks
 func (s *agent) Start(ctx context.Context) error {
 	if s.Config.MetricsAddr != "" {
 		observability.StartMetricsServer(ctx, s.Config.MetricsAddr)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, log logrus.FieldLogger, config *Config) (*agent, e
 		return nil, err
 	}
 
-	node := ethereum.NewNode(ctx, log, &config.Ethereum, config.Name)
+	node := ethereum.NewNode(ctx, log, &config.Ethereum, config.Name, config.Ethereum.SyncToleranceSlots)
 
 	indexerClient, err := indexer.NewClient(config.Indexer, log)
 	if err != nil {
@@ -131,8 +131,16 @@ func (s *agent) Start(ctx context.Context) error {
 				"purpose":    "execution_block_trace",
 			})
 
-			if !s.node.Execution().Metadata().IsSynced() {
-				logCtx.Debug("Skipping queueing execution block trace as the execution node is not yet synced")
+			// Check if the block is too old to bother fetching.
+			ignore, err := s.node.ShouldIgnoreEventFromSlot(event.Slot)
+			if err != nil {
+				logCtx.WithError(err).Error("Failed to check if the block is too old to fetch")
+
+				return err
+			}
+
+			if ignore {
+				logCtx.Debug("Skipping queueing execution block trace as the block is too old to fetch")
 
 				return nil
 			}
@@ -184,8 +192,19 @@ func (s *agent) Start(ctx context.Context) error {
 		}
 
 		s.node.Beacon().Node().OnBlock(ctx, func(ctx context.Context, event *eth2v1.BlockEvent) error {
-			if !s.node.Beacon().Metadata().Synced() {
-				s.log.Debug("Skipping queueing beacon state from block event as the beacon node is not yet synced")
+			logCtx := s.log.WithFields(logrus.Fields{
+				"event_topic": "block",
+				"slot":        event.Slot,
+				"root":        fmt.Sprintf("%#x", event.Block),
+				"purpose":     "beacon_state_and_block",
+			})
+
+			if ignore, err := s.node.ShouldIgnoreEventFromSlot(event.Slot); err != nil {
+				logCtx.WithError(err).Error("Failed to check if the block is too old to fetch")
+
+				return err
+			} else if ignore {
+				logCtx.Debug("Skipping queueing beacon state and block as the block is too old to fetch")
 
 				return nil
 			}

--- a/pkg/agent/ethereum/beacon/services/metadata.go
+++ b/pkg/agent/ethereum/beacon/services/metadata.go
@@ -231,9 +231,3 @@ func (m *MetadataService) NodeVersion(_ context.Context) string {
 func (m *MetadataService) Client(ctx context.Context) string {
 	return string(ClientFromString(m.NodeVersion(ctx)))
 }
-
-func (m *MetadataService) Synced() bool {
-	return !m.beacon.Status().Syncing() &&
-		m.beacon.Status().SyncState().HeadSlot > 0 &&
-		m.beacon.Status().SyncState().SyncDistance <= 16
-}

--- a/pkg/agent/ethereum/config.go
+++ b/pkg/agent/ethereum/config.go
@@ -3,6 +3,7 @@ package ethereum
 import (
 	"fmt"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/tracoor/pkg/agent/ethereum/beacon"
 	"github.com/ethpandaops/tracoor/pkg/agent/ethereum/execution"
 )
@@ -17,6 +18,9 @@ type Config struct {
 	OverrideNetworkName string `yaml:"overrideNetworkName"  default:""`
 	// Features configuration
 	Features Features `yaml:"features"`
+	// SyncToleranceSlots is the age of the block in slots that is tolerated before it is not fetched.
+	// This is to prevent fetching blocks that are too far behind the head.
+	SyncToleranceSlots phase0.Slot `yaml:"syncToleranceSlots" default:"64"`
 }
 
 func (c *Config) Validate() error {

--- a/pkg/server/persistence/db.go
+++ b/pkg/server/persistence/db.go
@@ -105,6 +105,11 @@ func (i *Indexer) Start(ctx context.Context) error {
 		return perrors.Wrap(err, "failed to auto migrate distributed lock")
 	}
 
+	err = i.db.AutoMigrate(&PermanentBlock{})
+	if err != nil {
+		return perrors.Wrap(err, "failed to auto migrate permanent block")
+	}
+
 	return nil
 }
 

--- a/pkg/server/persistence/operation.go
+++ b/pkg/server/persistence/operation.go
@@ -40,4 +40,9 @@ const (
 	OperationCountExecutionBadBlock  Operation = "count_execution_bad_block"
 	OperationListExecutionBadBlock   Operation = "list_execution_bad_block"
 	OperationUpdateExecutionBadBlock Operation = "update_execution_bad_block"
+
+	OperationInsertPermanentBlock Operation = "insert_permanent_block"
+	OperationGetPermanentBlock    Operation = "get_permanent_block"
+	OperationCountPermanentBlock  Operation = "count_permanent_block"
+	OperationListPermanentBlock   Operation = "list_permanent_block"
 )

--- a/pkg/server/persistence/permanent_block.go
+++ b/pkg/server/persistence/permanent_block.go
@@ -148,7 +148,7 @@ func (i *Indexer) GetPermanentBlockByBlockRoot(ctx context.Context, blockRoot, n
 	result := query.Where("block_root = ? AND network = ?", blockRoot, network).First(&permanentBlock)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
+			return nil, errors.New("permanent block not found")
 		}
 
 		i.metrics.ObserveOperationError(operation)
@@ -204,7 +204,6 @@ func (i *Indexer) DistinctPermanentBlockValues(ctx context.Context, fields []str
 	values := make([]interface{}, len(fields))
 
 	for rows.Next() {
-		values = make([]interface{}, len(fields))
 		valuePtrs := make([]interface{}, len(fields))
 
 		for i := range values {

--- a/pkg/server/persistence/permanent_block.go
+++ b/pkg/server/persistence/permanent_block.go
@@ -1,0 +1,245 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// PermanentBlock represents a permanently stored block in the database.
+// This provides a mapping between slot, block_root, and network for
+// blocks that have been copied to permanent storage.
+type PermanentBlock struct {
+	gorm.Model
+	// We have to use int64 here as SQLite doesn't support uint64
+	Slot      int64  `gorm:"index:idx_permanent_block_slot,where:deleted_at IS NULL;index:idx_permanent_block_slot_blockroot_network,where:deleted_at IS NULL,priority:1"`
+	BlockRoot string `gorm:"index:idx_permanent_block_blockroot,where:deleted_at IS NULL;index:idx_permanent_block_slot_blockroot_network,where:deleted_at IS NULL,priority:2"`
+	Network   string `gorm:"index:idx_permanent_block_network,where:deleted_at IS NULL;index:idx_permanent_block_slot_blockroot_network,where:deleted_at IS NULL,priority:3"`
+}
+
+type PermanentBlockFilter struct {
+	Slot      *int64
+	BlockRoot *string
+	Network   *string
+}
+
+func (f *PermanentBlockFilter) AddSlot(slot int64) {
+	f.Slot = &slot
+}
+
+func (f *PermanentBlockFilter) AddBlockRoot(blockRoot string) {
+	f.BlockRoot = &blockRoot
+}
+
+func (f *PermanentBlockFilter) AddNetwork(network string) {
+	f.Network = &network
+}
+
+func (f *PermanentBlockFilter) ApplyToQuery(query *gorm.DB) (*gorm.DB, error) {
+	if f.Slot != nil {
+		query = query.Where("slot = ?", f.Slot)
+	}
+
+	if f.BlockRoot != nil {
+		query = query.Where("block_root = ?", f.BlockRoot)
+	}
+
+	if f.Network != nil {
+		query = query.Where("network = ?", f.Network)
+	}
+
+	return query, nil
+}
+
+// InsertPermanentBlock inserts a permanent block record
+func (i *Indexer) InsertPermanentBlock(ctx context.Context, block *PermanentBlock) error {
+	operation := OperationInsertPermanentBlock
+	i.metrics.ObserveOperation(operation)
+
+	query := i.db.WithContext(ctx)
+
+	result := query.Create(block)
+	if result.Error != nil {
+		i.metrics.ObserveOperationError(operation)
+
+		return result.Error
+	}
+
+	return nil
+}
+
+// ListPermanentBlock lists permanent blocks based on the filter
+func (i *Indexer) ListPermanentBlock(ctx context.Context, filter *PermanentBlockFilter, pagination *PaginationCursor) ([]*PermanentBlock, error) {
+	operation := OperationListPermanentBlock
+	i.metrics.ObserveOperation(operation)
+
+	query := i.db.WithContext(ctx).Model(&PermanentBlock{})
+
+	query, err := filter.ApplyToQuery(query)
+	if err != nil {
+		i.metrics.ObserveOperationError(operation)
+
+		return nil, err
+	}
+
+	if pagination != nil {
+		if pagination.OrderBy != "" {
+			query = query.Order(pagination.OrderBy)
+		}
+
+		if pagination.Limit > 0 {
+			query = query.Limit(pagination.Limit)
+		}
+
+		if pagination.Offset > 0 {
+			query = query.Offset(pagination.Offset)
+		}
+	}
+
+	var permanentBlocks []*PermanentBlock
+
+	result := query.Find(&permanentBlocks)
+	if result.Error != nil {
+		i.metrics.ObserveOperationError(operation)
+
+		return nil, result.Error
+	}
+
+	return permanentBlocks, nil
+}
+
+// CountPermanentBlock counts permanent blocks based on the filter
+func (i *Indexer) CountPermanentBlock(ctx context.Context, filter *PermanentBlockFilter) (int64, error) {
+	operation := OperationCountPermanentBlock
+	i.metrics.ObserveOperation(operation)
+
+	query := i.db.WithContext(ctx).Model(&PermanentBlock{})
+
+	query, err := filter.ApplyToQuery(query)
+	if err != nil {
+		i.metrics.ObserveOperationError(operation)
+
+		return 0, err
+	}
+
+	var count int64
+
+	result := query.Count(&count)
+	if result.Error != nil {
+		i.metrics.ObserveOperationError(operation)
+
+		return 0, result.Error
+	}
+
+	return count, nil
+}
+
+// GetPermanentBlockByBlockRoot retrieves a permanent block by block root and network
+func (i *Indexer) GetPermanentBlockByBlockRoot(ctx context.Context, blockRoot, network string) (*PermanentBlock, error) {
+	operation := OperationGetPermanentBlock
+	i.metrics.ObserveOperation(operation)
+
+	query := i.db.WithContext(ctx).Model(&PermanentBlock{})
+
+	var permanentBlock PermanentBlock
+
+	result := query.Where("block_root = ? AND network = ?", blockRoot, network).First(&permanentBlock)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+
+		i.metrics.ObserveOperationError(operation)
+
+		return nil, result.Error
+	}
+
+	return &permanentBlock, nil
+}
+
+// DistinctPermanentBlockValues returns distinct values for permanent blocks
+type DistinctPermanentBlockValues struct {
+	Slot      []uint64
+	BlockRoot []string
+	Network   []string
+}
+
+// DistinctPermanentBlockValues gets distinct values for permanent blocks
+func (i *Indexer) DistinctPermanentBlockValues(ctx context.Context, fields []string) (*DistinctPermanentBlockValues, error) {
+	operation := OperationDistinctValues
+	i.metrics.ObserveOperation(operation)
+
+	results := &DistinctPermanentBlockValues{
+		Slot:      []uint64{},
+		BlockRoot: []string{},
+		Network:   []string{},
+	}
+
+	if len(fields) == 0 {
+		return results, nil
+	}
+
+	// Create maps to track values we've already seen
+	valueSets := make(map[string]map[interface{}]bool)
+
+	for _, field := range fields {
+		valueSets[field] = make(map[interface{}]bool)
+	}
+
+	// Create the SQL query with all fields
+	query := i.db.WithContext(ctx).
+		Model(&PermanentBlock{}).
+		Distinct(strings.Join(fields, ", "))
+
+	rows, err := query.Rows()
+	if err != nil {
+		i.metrics.ObserveOperationError(operation)
+
+		return nil, err
+	}
+	defer rows.Close()
+
+	values := make([]interface{}, len(fields))
+
+	for rows.Next() {
+		values = make([]interface{}, len(fields))
+		valuePtrs := make([]interface{}, len(fields))
+
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+
+		err := rows.Scan(valuePtrs...)
+		if err != nil {
+			i.metrics.ObserveOperationError(operation)
+
+			return nil, err
+		}
+
+		for i, field := range fields {
+			if !valueSets[field][values[i]] {
+				switch field {
+				case "slot":
+					//nolint:gosec // not worried about int64
+					results.Slot = append(results.Slot, uint64(values[i].(int64)))
+				case "block_root":
+					results.BlockRoot = append(results.BlockRoot, values[i].(string))
+				case "network":
+					results.Network = append(results.Network, values[i].(string))
+				}
+
+				valueSets[field][values[i]] = true
+			}
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		i.metrics.ObserveOperationError(operation)
+
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/pkg/server/persistence/permanent_block_test.go
+++ b/pkg/server/persistence/permanent_block_test.go
@@ -107,7 +107,7 @@ func TestGetPermanentBlockByBlockRoot(t *testing.T) {
 
 	// Try to get a non-existent block
 	result, err = indexer.GetPermanentBlockByBlockRoot(ctx, "non-existent", "test-network")
-	assert.NoError(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, result)
 }
 

--- a/pkg/server/persistence/permanent_block_test.go
+++ b/pkg/server/persistence/permanent_block_test.go
@@ -1,0 +1,173 @@
+//nolint:gosec // Only used in tests
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func generateRandomPermanentBlock() *PermanentBlock {
+	return &PermanentBlock{
+		Slot:      generateRandomInt64(),
+		BlockRoot: generateRandomString(32),
+		Network:   generateRandomString(5),
+	}
+}
+
+func TestInsertPermanentBlock(t *testing.T) {
+	indexer, mock, err := NewMockIndexer()
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	block := generateRandomPermanentBlock()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO").WithArgs(
+		sqlmock.AnyArg(), sqlmock.AnyArg(), nil, block.Slot,
+		block.BlockRoot, block.Network,
+	).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = indexer.InsertPermanentBlock(ctx, block)
+	assert.NoError(t, err)
+}
+
+func TestCountPermanentBlock(t *testing.T) {
+	indexer, _, err := NewMockIndexer()
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+
+	block := generateRandomPermanentBlock()
+
+	err = indexer.InsertPermanentBlock(ctx, block)
+	assert.NoError(t, err)
+
+	filter := &PermanentBlockFilter{}
+	filter.AddBlockRoot(block.BlockRoot)
+
+	count, err := indexer.CountPermanentBlock(ctx, filter)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestListPermanentBlock(t *testing.T) {
+	indexer, _, err := NewMockIndexer()
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Insert 3 blocks to test listing
+	for i := 0; i < 3; i++ {
+		block := generateRandomPermanentBlock()
+		block.Slot = int64(i + 1) // Ensure different slots
+		block.Network = "test-network"
+
+		err = indexer.InsertPermanentBlock(ctx, block)
+		assert.NoError(t, err)
+	}
+
+	// List all blocks
+	filter := &PermanentBlockFilter{}
+	filter.AddNetwork("test-network")
+
+	blocks, err := indexer.ListPermanentBlock(ctx, filter, &PaginationCursor{Limit: 10})
+	assert.NoError(t, err)
+	assert.Len(t, blocks, 3)
+
+	// Test pagination
+	blocks, err = indexer.ListPermanentBlock(ctx, filter, &PaginationCursor{Limit: 2})
+	assert.NoError(t, err)
+	assert.Len(t, blocks, 2)
+}
+
+func TestGetPermanentBlockByBlockRoot(t *testing.T) {
+	indexer, _, err := NewMockIndexer()
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	block := generateRandomPermanentBlock()
+	block.BlockRoot = "test-block-root"
+	block.Network = "test-network"
+
+	err = indexer.InsertPermanentBlock(ctx, block)
+	assert.NoError(t, err)
+
+	// Get the block by block root and network
+	result, err := indexer.GetPermanentBlockByBlockRoot(ctx, "test-block-root", "test-network")
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, block.BlockRoot, result.BlockRoot)
+	assert.Equal(t, block.Network, result.Network)
+	assert.Equal(t, block.Slot, result.Slot)
+
+	// Try to get a non-existent block
+	result, err = indexer.GetPermanentBlockByBlockRoot(ctx, "non-existent", "test-network")
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestDistinctPermanentBlockValues(t *testing.T) {
+	indexer, _, err := NewMockIndexer()
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Insert 20 blocks with some duplicate values
+	networks := []string{"mainnet", "goerli", "sepolia"}
+	slots := []int64{1, 2, 3, 4, 5}
+
+	for i := 0; i < 20; i++ {
+		block := &PermanentBlock{
+			Slot:      slots[i%len(slots)],
+			BlockRoot: fmt.Sprintf("block-root-%d", i),
+			Network:   networks[i%len(networks)],
+		}
+
+		err = indexer.InsertPermanentBlock(ctx, block)
+		assert.NoError(t, err)
+	}
+
+	// Test getting distinct values
+	distinctValues, err := indexer.DistinctPermanentBlockValues(ctx, []string{"network", "slot"})
+	assert.NoError(t, err)
+	assert.NotNil(t, distinctValues)
+
+	// Check that we have the right number of distinct networks
+	assert.Len(t, distinctValues.Network, len(networks))
+
+	for _, network := range networks {
+		found := false
+
+		for _, n := range distinctValues.Network {
+			if n == network {
+				found = true
+
+				break
+			}
+		}
+
+		assert.True(t, found, "Expected to find network %s in distinct values", network)
+	}
+
+	// Check that we have the right number of distinct slots
+	assert.Len(t, distinctValues.Slot, len(slots))
+
+	for _, slot := range slots {
+		found := false
+
+		for _, s := range distinctValues.Slot {
+			if uint64(slot) == s {
+				found = true
+
+				break
+			}
+		}
+
+		assert.True(t, found, "Expected to find slot %d in distinct values", slot)
+	}
+}

--- a/pkg/server/service/indexer/indexer.go
+++ b/pkg/server/service/indexer/indexer.go
@@ -485,8 +485,7 @@ func (i *Indexer) CreateBeaconBlock(ctx context.Context, req *indexer.CreateBeac
 		Location:  req.GetLocation().GetValue(),
 		BlockRoot: req.GetBlockRoot().GetValue(),
 		Network:   req.GetNetwork().GetValue(),
-		//nolint:gosec // This is a valid conversion
-		Slot: phase0.Slot(req.GetSlot().GetValue()),
+		Slot:      phase0.Slot(req.GetSlot().GetValue()),
 	})
 
 	return &indexer.CreateBeaconBlockResponse{

--- a/pkg/server/service/indexer/indexer.go
+++ b/pkg/server/service/indexer/indexer.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/tracoor/pkg/proto/tracoor/indexer"
 	"github.com/ethpandaops/tracoor/pkg/server/ethereum"
 	"github.com/ethpandaops/tracoor/pkg/server/persistence"
@@ -484,6 +485,8 @@ func (i *Indexer) CreateBeaconBlock(ctx context.Context, req *indexer.CreateBeac
 		Location:  req.GetLocation().GetValue(),
 		BlockRoot: req.GetBlockRoot().GetValue(),
 		Network:   req.GetNetwork().GetValue(),
+		//nolint:gosec // This is a valid conversion
+		Slot: phase0.Slot(req.GetSlot().GetValue()),
 	})
 
 	return &indexer.CreateBeaconBlockResponse{

--- a/pkg/server/service/indexer/permanent_store.go
+++ b/pkg/server/service/indexer/permanent_store.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/sirupsen/logrus"
 
@@ -18,6 +19,7 @@ type PermanentStoreBlock struct {
 	Location      string
 	BlockRoot     string
 	Network       string
+	Slot          phase0.Slot
 	ProcessedChan chan struct{}
 }
 
@@ -330,5 +332,5 @@ func (p *PermanentStore) getPermanentLocation(block PermanentStoreBlock) string 
 	// Extract the file extension from the source location
 	extension := filepath.Ext(block.Location)
 
-	return filepath.Join("permanent", block.Network, "blocks", block.BlockRoot+extension)
+	return filepath.Join("permanent", block.Network, "slots", fmt.Sprintf("%d", block.Slot), block.BlockRoot+extension)
 }

--- a/pkg/server/service/indexer/permanent_store.go
+++ b/pkg/server/service/indexer/permanent_store.go
@@ -360,6 +360,7 @@ func (p *PermanentStore) recordPermanentBlock(ctx context.Context, block Permane
 
 	// Record the block
 	return p.db.InsertPermanentBlock(ctx, &persistence.PermanentBlock{
+		//nolint:gosec // At the mercy of the database
 		Slot:      int64(block.Slot),
 		BlockRoot: block.BlockRoot,
 		Network:   block.Network,

--- a/pkg/server/service/indexer/permanent_store_test.go
+++ b/pkg/server/service/indexer/permanent_store_test.go
@@ -127,6 +127,7 @@ func TestPermanentStoreQueueAndProcess(t *testing.T) {
 		permanentBlocks, err := permanentStore.db.ListPermanentBlock(ctx, filter, &persistence.PaginationCursor{Limit: 1})
 		require.NoError(t, err)
 		assert.Len(t, permanentBlocks, 1, "Permanent block should be recorded in the database")
+		//nolint:gosec // slot is an int64
 		assert.Equal(t, int64(blockInfo.Slot), permanentBlocks[0].Slot, "Slot should match")
 		assert.Equal(t, blockInfo.BlockRoot, permanentBlocks[0].BlockRoot, "Block root should match")
 		assert.Equal(t, blockInfo.Network, permanentBlocks[0].Network, "Network should match")
@@ -597,14 +598,17 @@ func TestPermanentStoreLocation(t *testing.T) {
 
 	// Search for blocks by slot
 	filter := &persistence.PermanentBlockFilter{}
+	//nolint:gosec // slot is an int64
 	filter.AddSlot(int64(blockInfo.Slot))
 
 	blocks, err := permanentStore.db.ListPermanentBlock(ctx, filter, &persistence.PaginationCursor{Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, blocks, 1, "Should find one permanent block with the specified slot")
+
 	if len(blocks) > 0 {
 		assert.Equal(t, blockInfo.BlockRoot, blocks[0].BlockRoot)
 		assert.Equal(t, blockInfo.Network, blocks[0].Network)
+		//nolint:gosec // slot is an int64
 		assert.Equal(t, int64(blockInfo.Slot), blocks[0].Slot)
 	}
 }

--- a/pkg/server/service/indexer/permanent_store_test.go
+++ b/pkg/server/service/indexer/permanent_store_test.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -95,6 +94,7 @@ func TestPermanentStoreQueueAndProcess(t *testing.T) {
 			Location:      blockLocation,
 			BlockRoot:     "0x1234",
 			Network:       "mainnet",
+			Slot:          123,
 			ProcessedChan: processChan,
 		}
 
@@ -109,7 +109,7 @@ func TestPermanentStoreQueueAndProcess(t *testing.T) {
 		}
 
 		// Check if the block was copied to the permanent location
-		permanentLocation := filepath.Join("permanent", blockInfo.Network, "blocks", blockInfo.BlockRoot+filepath.Ext(blockLocation))
+		permanentLocation := permanentStore.GetPermanentLocation(blockInfo)
 		exists, err := mockStore.Exists(ctx, permanentLocation)
 		require.NoError(t, err)
 		assert.True(t, exists, "Block should be copied to permanent location")
@@ -118,6 +118,18 @@ func TestPermanentStoreQueueAndProcess(t *testing.T) {
 		data, err := mockStore.GetBeaconBlock(ctx, permanentLocation)
 		require.NoError(t, err)
 		assert.Equal(t, blockData, *data, "Block data should match")
+
+		// Check that the permanent block was recorded in the database
+		filter := &persistence.PermanentBlockFilter{}
+		filter.AddBlockRoot(blockInfo.BlockRoot)
+		filter.AddNetwork(blockInfo.Network)
+
+		permanentBlocks, err := permanentStore.db.ListPermanentBlock(ctx, filter, &persistence.PaginationCursor{Limit: 1})
+		require.NoError(t, err)
+		assert.Len(t, permanentBlocks, 1, "Permanent block should be recorded in the database")
+		assert.Equal(t, int64(blockInfo.Slot), permanentBlocks[0].Slot, "Slot should match")
+		assert.Equal(t, blockInfo.BlockRoot, permanentBlocks[0].BlockRoot, "Block root should match")
+		assert.Equal(t, blockInfo.Network, permanentBlocks[0].Network, "Network should match")
 	})
 }
 
@@ -144,6 +156,7 @@ func TestPermanentStoreProcessSameBlockTwice(t *testing.T) {
 		Location:      blockLocation,
 		BlockRoot:     "0x1234",
 		Network:       "mainnet",
+		Slot:          123,
 		ProcessedChan: processChan1,
 	}
 
@@ -159,12 +172,21 @@ func TestPermanentStoreProcessSameBlockTwice(t *testing.T) {
 	}
 
 	// Get the permanent location
-	permanentLocation := filepath.Join("permanent", blockInfo.Network, "blocks", blockInfo.BlockRoot+filepath.Ext(blockLocation))
+	permanentLocation := permanentStore.GetPermanentLocation(blockInfo)
 
 	// Verify it exists
 	exists, err := mockStore.Exists(ctx, permanentLocation)
 	require.NoError(t, err)
 	assert.True(t, exists, "Block should be copied to permanent location")
+
+	// Check that the permanent block was recorded in the database
+	filter := &persistence.PermanentBlockFilter{}
+	filter.AddBlockRoot(blockInfo.BlockRoot)
+	filter.AddNetwork(blockInfo.Network)
+
+	permanentBlocks, err := permanentStore.db.ListPermanentBlock(ctx, filter, &persistence.PaginationCursor{Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, permanentBlocks, 1, "Permanent block should be recorded in the database")
 
 	// Process the same block again with a new channel
 	processChan2 := make(chan struct{})
@@ -172,6 +194,7 @@ func TestPermanentStoreProcessSameBlockTwice(t *testing.T) {
 		Location:      blockLocation,
 		BlockRoot:     "0x1234",
 		Network:       "mainnet",
+		Slot:          123,
 		ProcessedChan: processChan2,
 	}
 	permanentStore.QueueBlock(blockInfo2)
@@ -188,6 +211,11 @@ func TestPermanentStoreProcessSameBlockTwice(t *testing.T) {
 	exists, err = mockStore.Exists(ctx, permanentLocation)
 	require.NoError(t, err)
 	assert.True(t, exists, "Block should still exist in permanent location")
+
+	// Check that there is still only one permanent block record
+	permanentBlocks, err = permanentStore.db.ListPermanentBlock(ctx, filter, &persistence.PaginationCursor{Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, permanentBlocks, 1, "There should still be only one permanent block record")
 }
 
 func TestPermanentStoreDifferentNetworks(t *testing.T) {
@@ -223,6 +251,7 @@ func TestPermanentStoreDifferentNetworks(t *testing.T) {
 		Location:      blockLocation1,
 		BlockRoot:     "0x1234",
 		Network:       "mainnet",
+		Slot:          123,
 		ProcessedChan: make(chan struct{}),
 	}
 
@@ -231,6 +260,7 @@ func TestPermanentStoreDifferentNetworks(t *testing.T) {
 		Location:      blockLocation2,
 		BlockRoot:     "0x1234", // Same root
 		Network:       "goerli", // Different network
+		Slot:          123,
 		ProcessedChan: make(chan struct{}),
 	}
 
@@ -255,8 +285,8 @@ func TestPermanentStoreDifferentNetworks(t *testing.T) {
 	}
 
 	// Check if both blocks were copied to their respective permanent locations
-	permanentLocation1 := filepath.Join("permanent", blockInfo1.Network, "blocks", blockInfo1.BlockRoot+filepath.Ext(blockLocation1))
-	permanentLocation2 := filepath.Join("permanent", blockInfo2.Network, "blocks", blockInfo2.BlockRoot+filepath.Ext(blockLocation2))
+	permanentLocation1 := permanentStore.GetPermanentLocation(blockInfo1)
+	permanentLocation2 := permanentStore.GetPermanentLocation(blockInfo2)
 
 	// Verify both exist
 	exists1, err := mockStore.Exists(ctx, permanentLocation1)
@@ -275,6 +305,23 @@ func TestPermanentStoreDifferentNetworks(t *testing.T) {
 	data2, err := mockStore.GetBeaconBlock(ctx, permanentLocation2)
 	require.NoError(t, err)
 	assert.Equal(t, blockData2, *data2, "Block data for goerli should match")
+
+	// Check that both permanent blocks were recorded in the database
+	filter1 := &persistence.PermanentBlockFilter{}
+	filter1.AddBlockRoot(blockInfo1.BlockRoot)
+	filter1.AddNetwork(blockInfo1.Network)
+
+	permanentBlocks1, err := permanentStore.db.ListPermanentBlock(ctx, filter1, &persistence.PaginationCursor{Limit: 1})
+	require.NoError(t, err)
+	assert.Len(t, permanentBlocks1, 1, "Permanent block should be recorded for mainnet")
+
+	filter2 := &persistence.PermanentBlockFilter{}
+	filter2.AddBlockRoot(blockInfo2.BlockRoot)
+	filter2.AddNetwork(blockInfo2.Network)
+
+	permanentBlocks2, err := permanentStore.db.ListPermanentBlock(ctx, filter2, &persistence.PaginationCursor{Limit: 1})
+	require.NoError(t, err)
+	assert.Len(t, permanentBlocks2, 1, "Permanent block should be recorded for goerli")
 }
 
 func TestPermanentStoreDistributedLock(t *testing.T) {
@@ -346,7 +393,7 @@ func TestPermanentStoreDistributedLock(t *testing.T) {
 	}
 
 	// Check if the block was copied to the permanent location
-	permanentLocation := filepath.Join("permanent", blockInfo1.Network, "blocks", blockInfo1.BlockRoot+filepath.Ext(blockLocation))
+	permanentLocation := permanentStore1.GetPermanentLocation(blockInfo1)
 	exists, err := mockStore.Exists(ctx, permanentLocation)
 	require.NoError(t, err)
 	assert.True(t, exists, "Block should be copied to permanent location")
@@ -418,6 +465,7 @@ func TestPermanentStoreStop(t *testing.T) {
 		BlockRoot:     "0xstop",
 		Network:       "mainnet",
 		ProcessedChan: processChan,
+		Slot:          1,
 	}
 
 	// Queue the block
@@ -432,7 +480,7 @@ func TestPermanentStoreStop(t *testing.T) {
 	}
 
 	// Verify the block was copied to the permanent location
-	permanentLocation := filepath.Join("permanent", blockInfo.Network, "blocks", blockInfo.BlockRoot+filepath.Ext(blockLocation))
+	permanentLocation := permanentStore.GetPermanentLocation(blockInfo)
 	exists, err := mockStore.Exists(ctx, permanentLocation)
 	require.NoError(t, err)
 	assert.True(t, exists, "Block should be copied to permanent location")
@@ -445,6 +493,7 @@ func TestPermanentStoreStop(t *testing.T) {
 		BlockRoot:     "0xqueued",
 		Network:       "mainnet",
 		ProcessedChan: processChan2,
+		Slot:          2,
 	}
 	permanentStore.QueueBlock(queuedBlock)
 
@@ -465,7 +514,7 @@ func TestPermanentStoreStop(t *testing.T) {
 	}
 
 	// Verify the queued block was copied to the permanent location
-	queuedLocation := filepath.Join("permanent", queuedBlock.Network, "blocks", queuedBlock.BlockRoot+filepath.Ext(blockLocation))
+	queuedLocation := permanentStore.GetPermanentLocation(queuedBlock)
 	exists, err = mockStore.Exists(ctx, queuedLocation)
 	require.NoError(t, err)
 	assert.True(t, exists, "Queued block should be copied to permanent location before Stop completes")
@@ -480,9 +529,11 @@ func TestPermanentStoreStop(t *testing.T) {
 
 	// Try to queue a block after stopping
 	unprocessedBlock := PermanentStoreBlock{
-		Location:  blockLocation,
-		BlockRoot: "0xunprocessed",
-		Network:   "mainnet",
+		Location:      blockLocation,
+		BlockRoot:     "0xunprocessed",
+		Network:       "mainnet",
+		ProcessedChan: make(chan struct{}),
+		Slot:          3,
 	}
 	permanentStore.QueueBlock(unprocessedBlock)
 
@@ -490,11 +541,70 @@ func TestPermanentStoreStop(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Verify the unprocessed block was not copied to the permanent location
-	unprocessedLocation := filepath.Join("permanent", unprocessedBlock.Network, "blocks", unprocessedBlock.BlockRoot+filepath.Ext(blockLocation))
+	unprocessedLocation := permanentStore.GetPermanentLocation(unprocessedBlock)
 	exists, err = mockStore.Exists(ctx, unprocessedLocation)
 	require.NoError(t, err)
 	assert.False(t, exists, "Block should not be copied after permanent store is stopped")
 
 	// Verify that the stopped flag is set
 	assert.True(t, permanentStore.stopped, "Stopped flag should be set")
+}
+
+func TestPermanentStoreLocation(t *testing.T) {
+	ctx := context.Background()
+	permanentStore, mockStore, cleanup := setupPermanentStore(t)
+
+	defer cleanup()
+
+	// Create a block with known values
+	blockInfo := PermanentStoreBlock{
+		Location:  "test/location/block.ssz",
+		BlockRoot: "0xabcd1234",
+		Network:   "mainnet",
+		Slot:      123456,
+	}
+
+	// Get the permanent location
+	permanentLocation := permanentStore.GetPermanentLocation(blockInfo)
+
+	// Verify the location format
+	expectedLocation := "permanent/mainnet/0xabcd1234.ssz"
+	assert.Equal(t, expectedLocation, permanentLocation, "Permanent location should not include slot in the path")
+
+	// Create a test file at the source location
+	data := []byte("test data")
+	params := &store.SaveParams{
+		Location: blockInfo.Location,
+		Data:     &data,
+	}
+	_, err := mockStore.SaveBeaconBlock(ctx, params)
+	require.NoError(t, err)
+
+	// Verify we can find blocks by querying the permanent block table
+	processChan := make(chan struct{})
+	blockInfo.ProcessedChan = processChan
+
+	// Queue the block for processing
+	permanentStore.QueueBlock(blockInfo)
+
+	// Wait for processing to complete
+	select {
+	case <-processChan:
+		// Block processed
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Block processing timed out")
+	}
+
+	// Search for blocks by slot
+	filter := &persistence.PermanentBlockFilter{}
+	filter.AddSlot(int64(blockInfo.Slot))
+
+	blocks, err := permanentStore.db.ListPermanentBlock(ctx, filter, &persistence.PaginationCursor{Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, blocks, 1, "Should find one permanent block with the specified slot")
+	if len(blocks) > 0 {
+		assert.Equal(t, blockInfo.BlockRoot, blocks[0].BlockRoot)
+		assert.Equal(t, blockInfo.Network, blocks[0].Network)
+		assert.Equal(t, int64(blockInfo.Slot), blocks[0].Slot)
+	}
 }

--- a/pkg/server/service/indexer/retention.go
+++ b/pkg/server/service/indexer/retention.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/tracoor/pkg/server/persistence"
 	"github.com/ethpandaops/tracoor/pkg/store"
 	"github.com/sirupsen/logrus"
@@ -120,6 +121,8 @@ func (i *Indexer) purgeOldBeaconBlocks(ctx context.Context) error {
 			BlockRoot:     block.BlockRoot,
 			Network:       block.Network,
 			ProcessedChan: make(chan struct{}),
+			//nolint:gosec // This is a valid conversion
+			Slot: phase0.Slot(block.Slot),
 		}
 
 		i.permanentStore.QueueBlock(b)

--- a/pkg/store/s3.go
+++ b/pkg/store/s3.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -781,31 +780,77 @@ func (s *S3Store) Copy(ctx context.Context, params *CopyParams) error {
 		return errors.New("source and destination are required")
 	}
 
-	// AWS SDK v2 expects the CopySource to be in the format:
-	// bucketName + "/" + objectKey with proper URL encoding
-	// For R2 and S3-compatible services like MinIO, the format needs to be precise
-
-	// First create the unencoded version for logging
-	rawSource := fmt.Sprintf("%s/%s", s.config.BucketName, params.Source)
-
-	// Now create the properly encoded version using standard URL encoding
-	// but preserving the forward slashes, which is what AWS S3 API expects
-	copySource := url.QueryEscape(s.config.BucketName) + "/" + strings.ReplaceAll(url.QueryEscape(params.Source), "%2F", "/")
-
+	// Log the copy operation attempt
 	s.log.WithFields(logrus.Fields{
-		"source":        params.Source,
-		"destination":   params.Destination,
-		"rawSource":     rawSource,
-		"encodedSource": copySource,
-	}).Debug("Performing server side copy")
+		"source":      params.Source,
+		"destination": params.Destination,
+	}).Debug("Performing object copy")
 
+	// First try to do a regular server-side copy (works with MinIO and S3)
 	_, err := s.s3Client.CopyObject(ctx, &s3.CopyObjectInput{
 		Bucket:     aws.String(s.config.BucketName),
-		CopySource: aws.String(copySource),
+		CopySource: aws.String(fmt.Sprintf("%s/%s", s.config.BucketName, params.Source)),
 		Key:        aws.String(params.Destination),
 	})
 
-	return err
+	// If the server-side copy was successful, return
+	if err == nil {
+		return nil
+	}
+
+	// If we got an error, check if it's a specific R2 error or a general error
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		// For R2, we need to use GetObject + PutObject as a workaround
+		// But we only do this for specific errors that indicate a compatibility issue
+		// Log that we're falling back to the manual copy method
+		s.log.WithFields(logrus.Fields{
+			"source":      params.Source,
+			"destination": params.Destination,
+			"error":       apiErr.Error(),
+			"errorCode":   apiErr.ErrorCode(),
+		}).Debug("Server-side copy failed, falling back to GetObject + PutObject method")
+
+		// Get the source object
+		getResult, getErr := s.s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(s.config.BucketName),
+			Key:    aws.String(params.Source),
+		})
+		if getErr != nil {
+			return fmt.Errorf("failed to get source object for manual copy: %w", getErr)
+		}
+		defer getResult.Body.Close()
+
+		// Read the source object content
+		buf := new(bytes.Buffer)
+		if _, readErr := buf.ReadFrom(getResult.Body); readErr != nil {
+			return fmt.Errorf("failed to read source object content: %w", readErr)
+		}
+
+		// Create the put input with the same metadata as the source
+		putInput := &s3.PutObjectInput{
+			Bucket:             aws.String(s.config.BucketName),
+			Key:                aws.String(params.Destination),
+			Body:               bytes.NewReader(buf.Bytes()),
+			ContentType:        getResult.ContentType,
+			ContentDisposition: getResult.ContentDisposition,
+			ContentEncoding:    getResult.ContentEncoding,
+			ContentLanguage:    getResult.ContentLanguage,
+			CacheControl:       getResult.CacheControl,
+			Expires:            getResult.Expires,
+		}
+
+		// Put the object
+		_, putErr := s.s3Client.PutObject(ctx, putInput)
+		if putErr != nil {
+			return fmt.Errorf("failed to put object in manual copy: %w", putErr)
+		}
+
+		return nil
+	}
+
+	// If not an API error, return the original error
+	return fmt.Errorf("failed to copy object: %w", err)
 }
 
 func (s *S3Store) PreferURLs() bool {


### PR DESCRIPTION
- Removes sync checks based on the node status. This is one of the learnings from Holesky. We can't trust the beacon node to accurately report it's sync status, and would prefer to over-index data instead of dropping it. We now take a different approach, comparing the wall clock slot with the slot from the event stream to determine if we should fetch data.
- Fixes permanent block storage on R2, which requires a download/upload instead of a server-side copy
