### PR TITLE
feat(server): promotion service — interesting-states corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ Flags:
   -h, --help            help for server
 ```
 
+#### Promotion service (interesting states corpus)
+
+The server can optionally run a promotion service that watches the
+short-retention capture buffer with hindsight and copies "interesting"
+consensus captures — as a replayable `(parent post-state, block)` pair plus a
+`manifest.json` — into a separate, global, append-only S3 bucket that outlives
+every devnet. Interesting means: slashings, exits, deposits, execution
+requests, missed-block runs, reorgs (both branches), fork boundaries,
+low sync participation, undecodable (brand-new) forks, plus a periodic
+baseline. A per-network hourly rate cap bounds volume; the service never
+deletes anything and keeps no persistent state.
+
+The corpus layout is self-describing:
+
+```
+v1/states/<sha256-of-raw-ssz>.ssz                       # uncompressed, content-addressed
+v1/captures/<network>/<fork>/<capture_id>/input.ssz     # the SignedBeaconBlock, raw
+v1/captures/<network>/<fork>/<capture_id>/manifest.json
+```
+
+See the `services.promotion` section of the [example config](https://github.com/ethpandaops/tracoor/blob/master/example_server_config.yaml).
+It is opt-in and requires the beacon state/block retention to exceed the
+configured processing lag.
+
 ### Agent
 
 Tracoor agent requires a config file. An example file can be found [here](https://github.com/ethpandaops/tracoor/blob/master/example_agent_config.yaml).

--- a/README.md
+++ b/README.md
@@ -93,10 +93,14 @@ consensus captures — as a replayable `(parent post-state, block)` pair plus a
 every devnet. Interesting means: slashings, exits, deposits, execution
 requests, missed-block runs, reorgs (both branches), fork boundaries,
 low sync participation, undecodable (brand-new) forks, plus a periodic
-baseline. Two per-network hourly rate budgets bound volume (a common one for
-repetitive symptoms, a separate one for rare events so they never compete
-with floods; reorgs are uncapped); the service never
-deletes anything and keeps no persistent state.
+baseline. Three per-network hourly rate budgets bound volume: a common one for
+repetitive symptoms, a separate one for rare events so they never compete with
+floods, and a deliberately generous one for reorgs. The service never deletes
+anything and keeps no persistent state.
+
+Devnets are recreated under the same name constantly, so the service tracks
+each network's genesis validators root and rebuilds its cursor when the chain
+behind a name changes or loses height.
 
 The corpus layout is self-describing:
 
@@ -107,8 +111,9 @@ v1/captures/<network>/<fork>/<capture_id>/manifest.json
 ```
 
 See the `services.promotion` section of the [example config](https://github.com/ethpandaops/tracoor/blob/master/example_server_config.yaml).
-It is opt-in and requires the beacon state/block retention to exceed the
-configured processing lag.
+It is opt-in, requires the beacon state/block retention to exceed the
+configured processing lag, and requires a corpus store distinct from the
+capture buffer's.
 
 ### Agent
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ consensus captures — as a replayable `(parent post-state, block)` pair plus a
 every devnet. Interesting means: slashings, exits, deposits, execution
 requests, missed-block runs, reorgs (both branches), fork boundaries,
 low sync participation, undecodable (brand-new) forks, plus a periodic
-baseline. A per-network hourly rate cap bounds volume; the service never
+baseline. Two per-network hourly rate budgets bound volume (a common one for
+repetitive symptoms, a separate one for rare events so they never compete
+with floods; reorgs are uncapped); the service never
 deletes anything and keeps no persistent state.
 
 The corpus layout is self-describing:

--- a/example_server_config.yaml
+++ b/example_server_config.yaml
@@ -28,7 +28,8 @@ services:
   #   checkInterval: 30s
   #   slotsPerEpoch: 32
   #   secondsPerSlot: 12s
-  #   rateCapPerHour: 30
+  #   rateCapPerHour: 30       # common tier: gap/participation/baseline floods
+  #   rareCapPerHour: 120      # rare tier: slashings/exits/etc never compete with floods
   #   baselineEveryNEpochs: 8
   #   gapTrigger: 2
   #   syncParticipationFloor: 0.95

--- a/example_server_config.yaml
+++ b/example_server_config.yaml
@@ -30,6 +30,9 @@ services:
   #   secondsPerSlot: 12s
   #   rateCapPerHour: 30       # common tier: gap/participation/baseline floods
   #   rareCapPerHour: 120      # rare tier: slashings/exits/etc never compete with floods
+  #   reorgCapPerHour: 1000    # reorg tier: generous, but still a ceiling
+  #   # A cap of 0 promotes nothing in that tier; to drop a class of captures,
+  #   # disable its trigger instead.
   #   baselineEveryNEpochs: 8
   #   gapTrigger: 2
   #   syncParticipationFloor: 0.95
@@ -45,7 +48,8 @@ services:
   #     forkBoundary: true
   #     undecodableFork: true
   #     baseline: true
-  #   store:                 # the corpus bucket; use write-only credentials (no delete)
+  #   store:                 # the corpus bucket; must NOT be the buffer bucket above.
+  #                          # Use credentials without delete: PutObject/GetObject/ListBucket.
   #     type: s3
   #     config:
   #       region: "us-east-1"

--- a/example_server_config.yaml
+++ b/example_server_config.yaml
@@ -18,6 +18,40 @@ services:
       beaconBadBlobs: 30m
       executionBlockTrace: 30m
       executionBadBlocks: 30m
+  # Promote "interesting" (pre-state, block) pairs from the retention buffer
+  # into a separate, append-only corpus bucket. Opt-in.
+  # NOTE: beaconStates/beaconBlocks retention must exceed
+  # (lagEpochs + 1) * slotsPerEpoch * secondsPerSlot, or the server refuses to start.
+  # promotion:
+  #   enabled: true
+  #   lagEpochs: 2
+  #   checkInterval: 30s
+  #   slotsPerEpoch: 32
+  #   secondsPerSlot: 12s
+  #   rateCapPerHour: 30
+  #   baselineEveryNEpochs: 8
+  #   gapTrigger: 2
+  #   syncParticipationFloor: 0.95
+  #   triggers:              # per-trigger toggles, all default true
+  #     slashing: true
+  #     voluntaryExit: true
+  #     blsToExecutionChange: true
+  #     deposit: true
+  #     executionRequest: true
+  #     gap: true
+  #     reorg: true
+  #     lowParticipation: true
+  #     forkBoundary: true
+  #     undecodableFork: true
+  #     baseline: true
+  #   store:                 # the corpus bucket; use write-only credentials (no delete)
+  #     type: s3
+  #     config:
+  #       region: "us-east-1"
+  #       endpoint: http://minio:9000
+  #       bucket_name: interesting-states
+  #       access_key: xxx
+  #       access_secret: xxx
   # Use the following to configure Tracoor for a custom network
   # ethereum:
   #   config:

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
@@ -124,7 +125,6 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15 // indirect
 	github.com/r3labs/sse/v2 v2.10.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/pkg/server/persistence/beacon_block.go
+++ b/pkg/server/persistence/beacon_block.go
@@ -16,15 +16,18 @@ type BeaconBlock struct {
 	// We have to use int64 here as SQLite doesn't support uint64. This sucks
 	// but slot 9223372036854775808 is probably around the heat death
 	// of the universe so we should be OK.
-	Slot                 int64 `gorm:"index:idx_beacon_block_slot,where:deleted_at IS NULL;index;index:idx_beacon_block_node_slot_blockroot_network_fetchedat,where:deleted_at IS NULL,priority:2"`
-	Epoch                int64
+	Slot int64 `gorm:"index:idx_beacon_block_slot,where:deleted_at IS NULL;index;index:idx_beacon_block_node_slot_blockroot_network_fetchedat,where:deleted_at IS NULL,priority:2"`
+	// The promotion service walks the index one (network, epoch) at a time,
+	// so this pair is indexed; an unindexed epoch turns each of those
+	// listings into a full table scan.
+	Epoch                int64     `gorm:"index:idx_beacon_block_network_epoch,where:deleted_at IS NULL,priority:2"`
 	BlockRoot            string    `gorm:"index;index:idx_beacon_block_node_slot_blockroot_network_fetchedat,where:deleted_at IS NULL,priority:3"`
 	FetchedAt            time.Time `gorm:"index;index:idx_beacon_block_node_slot_blockroot_network_fetchedat,where:deleted_at IS NULL,priority:5;index:idx_beacon_block_fetchedat,where:deleted_at IS NULL;index:idx_beacon_block_fetchedat_network,where:deleted_at IS NULL,priority:1"`
 	BeaconImplementation string
 	NodeVersion          string `gorm:"not null;default:''"`
 	ContentEncoding      string `gorm:"not null;default:''"`
 	Location             string `gorm:"not null;default:''"`
-	Network              string `gorm:"not null;default:'';index;index:idx_beacon_block_node_slot_blockroot_network_fetchedat,where:deleted_at IS NULL,priority:4;index:idx_beacon_block_network,where:deleted_at IS NULL;index:idx_beacon_block_network,where:deleted_at IS NULL;index:idx_beacon_block_fetchedat_network,where:deleted_at IS NULL,priority:2"`
+	Network              string `gorm:"not null;default:'';index;index:idx_beacon_block_node_slot_blockroot_network_fetchedat,where:deleted_at IS NULL,priority:4;index:idx_beacon_block_network,where:deleted_at IS NULL;index:idx_beacon_block_network,where:deleted_at IS NULL;index:idx_beacon_block_fetchedat_network,where:deleted_at IS NULL,priority:2;index:idx_beacon_block_network_epoch,where:deleted_at IS NULL,priority:1"`
 }
 
 type BeaconBlockFilter struct {

--- a/pkg/server/persistence/beacon_state.go
+++ b/pkg/server/persistence/beacon_state.go
@@ -16,15 +16,17 @@ type BeaconState struct {
 	// We have to use int64 here as SQLite doesn't support uint64. This sucks
 	// but slot 9223372036854775808 is probably around the heat death
 	// of the universe so we should be OK.
-	Slot                 int64 `gorm:"index:idx_beacon_state_slot,where:deleted_at IS NULL;index;index:idx_beacon_state_node_slot_stateroot_network_fetchedat,where:deleted_at IS NULL,priority:2"`
-	Epoch                int64
+	Slot int64 `gorm:"index:idx_beacon_state_slot,where:deleted_at IS NULL;index;index:idx_beacon_state_node_slot_stateroot_network_fetchedat,where:deleted_at IS NULL,priority:2"`
+	// Indexed alongside network to match the promotion service's per-epoch
+	// walk; see the equivalent index on BeaconBlock.
+	Epoch                int64     `gorm:"index:idx_beacon_state_network_epoch,where:deleted_at IS NULL,priority:2"`
 	StateRoot            string    `gorm:"index;index:idx_beacon_state_node_slot_stateroot_network_fetchedat,where:deleted_at IS NULL,priority:3"`
 	FetchedAt            time.Time `gorm:"index;index:idx_beacon_state_node_slot_stateroot_network_fetchedat,where:deleted_at IS NULL,priority:5;index:idx_beacon_state_fetchedat,where:deleted_at IS NULL;index:idx_beacon_state_fetchedat_network,where:deleted_at IS NULL,priority:1"`
 	BeaconImplementation string
 	NodeVersion          string `gorm:"not null;default:''"`
 	ContentEncoding      string `gorm:"not null;default:''"`
 	Location             string `gorm:"not null;default:''"`
-	Network              string `gorm:"not null;default:'';index;index:idx_beacon_state_node_slot_stateroot_network_fetchedat,where:deleted_at IS NULL,priority:4;index:idx_beacon_state_network,where:deleted_at IS NULL;index:idx_beacon_state_network,where:deleted_at IS NULL;index:idx_beacon_state_fetchedat_network,where:deleted_at IS NULL,priority:2"`
+	Network              string `gorm:"not null;default:'';index;index:idx_beacon_state_node_slot_stateroot_network_fetchedat,where:deleted_at IS NULL,priority:4;index:idx_beacon_state_network,where:deleted_at IS NULL;index:idx_beacon_state_network,where:deleted_at IS NULL;index:idx_beacon_state_fetchedat_network,where:deleted_at IS NULL,priority:2;index:idx_beacon_state_network_epoch,where:deleted_at IS NULL,priority:1"`
 }
 
 type BeaconStateFilter struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -78,7 +78,7 @@ func NewServer(ctx context.Context, log logrus.FieldLogger, conf *Config) (*Serv
 
 	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-	services, err := service.CreateGRPCServices(ctx, log, &conf.Services, db, st, conf.Addr, opts, &conf.Ethereum)
+	services, err := service.CreateGRPCServices(ctx, log, &conf.Services, db, st, conf.Store, conf.Addr, opts, &conf.Ethereum)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/service/config.go
+++ b/pkg/server/service/config.go
@@ -3,11 +3,13 @@ package service
 import (
 	"github.com/ethpandaops/tracoor/pkg/server/service/api"
 	"github.com/ethpandaops/tracoor/pkg/server/service/indexer"
+	"github.com/ethpandaops/tracoor/pkg/server/service/promotion"
 )
 
 type Config struct {
-	Indexer indexer.Config `yaml:"indexer"`
-	API     api.Config     `yaml:"api"`
+	Indexer   indexer.Config   `yaml:"indexer"`
+	API       api.Config       `yaml:"api"`
+	Promotion promotion.Config `yaml:"promotion"`
 }
 
 func (c *Config) Validate() error {
@@ -16,6 +18,10 @@ func (c *Config) Validate() error {
 	}
 
 	if err := c.API.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.Promotion.Validate(); err != nil {
 		return err
 	}
 

--- a/pkg/server/service/promotion/config.go
+++ b/pkg/server/service/promotion/config.go
@@ -30,11 +30,18 @@ type Config struct {
 	SlotsPerEpoch  uint64         `yaml:"slotsPerEpoch" default:"32"`
 	SecondsPerSlot human.Duration `yaml:"secondsPerSlot" default:"12s"`
 
-	// RateCapPerHour caps promotions per network per hour. It is the only
-	// flood guard: when exhausted the service skips - it never queues and
-	// never deletes. Reorg promotions bypass the cap (self-limiting and the
-	// highest-value class).
+	// RateCapPerHour caps common-tier promotions (gap, low_participation,
+	// baseline, undecodable_fork, deposit, execution_request) per network
+	// per hour. It is the flood guard: when exhausted the service skips -
+	// it never queues and never deletes.
 	RateCapPerHour uint64 `yaml:"rateCapPerHour" default:"30"`
+
+	// RareCapPerHour is a separate budget for rare-tier promotions
+	// (slashing, voluntary_exit, bls_to_execution_change, fork_boundary),
+	// so the rarest captures never compete with a participation/gap flood
+	// during a stall, while a mass-slashing incident still meets a hard
+	// ceiling. Reorg promotions are uncapped (self-limiting per slot).
+	RareCapPerHour uint64 `yaml:"rareCapPerHour" default:"120"`
 
 	// BaselineEveryNEpochs promotes the first qualifying slot of every Nth
 	// epoch regardless of triggers; a corpus of only pathologies is its own

--- a/pkg/server/service/promotion/config.go
+++ b/pkg/server/service/promotion/config.go
@@ -34,16 +34,33 @@ type Config struct {
 	// baseline, undecodable_fork, deposit, execution_request) per network
 	// per hour. It is the flood guard: when exhausted the service skips -
 	// it never queues and never deletes.
+	//
+	// The window is tumbling, not sliding: it resets an hour after its first
+	// promotion, so a burst straddling the boundary can spend two budgets
+	// within a few minutes. That is deliberate - the cap bounds sustained
+	// volume, not instantaneous burstiness.
+	//
+	// A cap of 0 promotes nothing in that tier. To drop a class of captures,
+	// prefer disabling its trigger: a zero cap is indistinguishable in the
+	// metrics from a permanently exhausted budget.
 	RateCapPerHour uint64 `yaml:"rateCapPerHour" default:"30"`
 
 	// RareCapPerHour is a separate budget for rare-tier promotions
 	// (slashing, voluntary_exit, bls_to_execution_change, fork_boundary),
 	// so the rarest captures never compete with a participation/gap flood
 	// during a stall, while a mass-slashing incident still meets a hard
-	// ceiling. Reorg promotions are uncapped (self-limiting per slot).
+	// ceiling.
 	RareCapPerHour uint64 `yaml:"rareCapPerHour" default:"120"`
 
-	// BaselineEveryNEpochs promotes the first qualifying slot of every Nth
+	// ReorgCapPerHour is a deliberately generous ceiling for reorg
+	// promotions. Reorgs are self-limiting per slot and the orphaned branch
+	// is unobtainable anywhere else, so they get their own budget rather
+	// than competing with anything - but "self-limiting per slot" is not a
+	// bound in aggregate: an equivocation storm, or an agent inserting many
+	// distinct roots per slot, is otherwise unbounded corpus spend.
+	ReorgCapPerHour uint64 `yaml:"reorgCapPerHour" default:"1000"`
+
+	// BaselineEveryNEpochs promotes the lowest indexed slot of every Nth
 	// epoch regardless of triggers; a corpus of only pathologies is its own
 	// blind spot. Fires on epoch%N == 0 so re-processing selects the same
 	// slots.
@@ -94,8 +111,11 @@ func (c *Config) Validate() error {
 		return errors.New("promotion: slotsPerEpoch must be > 0")
 	}
 
-	if c.SecondsPerSlot.Duration <= 0 {
-		return errors.New("promotion: secondsPerSlot must be > 0")
+	// Manifests record seconds_per_slot as an integer, so a sub-second value
+	// would be published as 0 rather than truncated silently. No beacon
+	// chain spec uses one.
+	if c.SecondsPerSlot.Duration < time.Second {
+		return errors.New("promotion: secondsPerSlot must be >= 1s")
 	}
 
 	if c.CheckInterval.Duration <= 0 {
@@ -111,6 +131,73 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// Store config fields that decide whether two store configs address the same
+// physical destination.
+const (
+	keyEndpoint   = "endpoint"
+	keyBucketName = "bucket_name"
+	keyBasePath   = "base_path"
+)
+
+var identityKeys = map[store.Type][]string{
+	store.S3StoreType: {keyEndpoint, keyBucketName},
+	store.FSStoreType: {keyBasePath},
+}
+
+// ValidateDistinctFrom refuses a corpus store that addresses the same
+// destination as the buffer store. The corpus is append-only and outlives
+// every devnet; the buffer is reaped on a schedule. Sharing a bucket between
+// them is never intended, and the failure mode - corpus objects sitting in a
+// bucket somebody eventually points a lifecycle rule at - is silent.
+func (c *Config) ValidateDistinctFrom(buffer store.Config) error {
+	if !c.Enabled || c.Store.Type != buffer.Type {
+		return nil
+	}
+
+	keys, ok := identityKeys[c.Store.Type]
+	if !ok {
+		return nil
+	}
+
+	corpusCfg, err := rawConfigMap(c.Store)
+	if err != nil {
+		return fmt.Errorf("promotion store: %w", err)
+	}
+
+	bufferCfg, err := rawConfigMap(buffer)
+	if err != nil {
+		return fmt.Errorf("promotion store: %w", err)
+	}
+
+	if len(corpusCfg) == 0 || len(bufferCfg) == 0 {
+		return nil
+	}
+
+	for _, key := range keys {
+		if fmt.Sprint(corpusCfg[key]) != fmt.Sprint(bufferCfg[key]) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"promotion: the corpus store addresses the same %s destination as the buffer store (%v); the corpus must be a separate, append-only location",
+		c.Store.Type, keys,
+	)
+}
+
+func rawConfigMap(conf store.Config) (map[string]any, error) {
+	out := map[string]any{}
+	if conf.Config.IsZero() {
+		return out, nil
+	}
+
+	if err := conf.Config.Unmarshal(&out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }
 
 // ValidateRetention refuses to run when the buffer cannot outlive the

--- a/pkg/server/service/promotion/config.go
+++ b/pkg/server/service/promotion/config.go
@@ -1,0 +1,129 @@
+package promotion
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethpandaops/beacon/pkg/human"
+	"github.com/ethpandaops/tracoor/pkg/store"
+)
+
+// Config configures the promotion service, which copies "interesting"
+// (pre-state, block) pairs from the short-retention buffer into a separate,
+// append-only corpus store.
+type Config struct {
+	// Enabled turns the service on. Opt-in.
+	Enabled bool `yaml:"enabled" default:"false"`
+
+	// LagEpochs is how many epochs behind the freshest indexed epoch the
+	// service processes. Hindsight is load-bearing: it is what makes both
+	// branches of a reorg available in the buffer.
+	LagEpochs uint64 `yaml:"lagEpochs" default:"2"`
+
+	// CheckInterval is how often the service looks for newly lagged epochs.
+	CheckInterval human.Duration `yaml:"checkInterval" default:"30s"`
+
+	// SlotsPerEpoch and SecondsPerSlot describe the target network(s). They
+	// feed the retention safety check and the manifests; epoch grouping
+	// itself uses the agent-computed epoch column of the index.
+	SlotsPerEpoch  uint64         `yaml:"slotsPerEpoch" default:"32"`
+	SecondsPerSlot human.Duration `yaml:"secondsPerSlot" default:"12s"`
+
+	// RateCapPerHour caps promotions per network per hour. It is the only
+	// flood guard: when exhausted the service skips - it never queues and
+	// never deletes. Reorg promotions bypass the cap (self-limiting and the
+	// highest-value class).
+	RateCapPerHour uint64 `yaml:"rateCapPerHour" default:"30"`
+
+	// BaselineEveryNEpochs promotes the first qualifying slot of every Nth
+	// epoch regardless of triggers; a corpus of only pathologies is its own
+	// blind spot. Fires on epoch%N == 0 so re-processing selects the same
+	// slots.
+	BaselineEveryNEpochs uint64 `yaml:"baselineEveryNEpochs" default:"8"`
+
+	// GapTrigger is the minimum run of skipped slots before a block that
+	// fires the gap trigger.
+	GapTrigger uint64 `yaml:"gapTrigger" default:"2"`
+
+	// SyncParticipationFloor fires the low_participation trigger when the
+	// sync committee bit density falls below it. Requires a typed decode.
+	SyncParticipationFloor float64 `yaml:"syncParticipationFloor" default:"0.95"`
+
+	// Triggers toggles individual triggers. All default to enabled.
+	Triggers TriggersConfig `yaml:"triggers"`
+
+	// Store is the corpus store. It must not be the buffer store, and its
+	// credentials should be write-only (no delete): the service never
+	// deletes anything, anywhere.
+	Store store.Config `yaml:"store"`
+}
+
+// TriggersConfig holds per-trigger toggles. A nil value means enabled.
+type TriggersConfig struct {
+	Slashing             *bool `yaml:"slashing"`
+	VoluntaryExit        *bool `yaml:"voluntaryExit"`
+	BLSToExecutionChange *bool `yaml:"blsToExecutionChange"`
+	Deposit              *bool `yaml:"deposit"`
+	ExecutionRequest     *bool `yaml:"executionRequest"`
+	Gap                  *bool `yaml:"gap"`
+	Reorg                *bool `yaml:"reorg"`
+	LowParticipation     *bool `yaml:"lowParticipation"`
+	ForkBoundary         *bool `yaml:"forkBoundary"`
+	UndecodableFork      *bool `yaml:"undecodableFork"`
+	Baseline             *bool `yaml:"baseline"`
+}
+
+func triggerEnabled(v *bool) bool {
+	return v == nil || *v
+}
+
+func (c *Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.SlotsPerEpoch == 0 {
+		return errors.New("promotion: slotsPerEpoch must be > 0")
+	}
+
+	if c.SecondsPerSlot.Duration <= 0 {
+		return errors.New("promotion: secondsPerSlot must be > 0")
+	}
+
+	if c.CheckInterval.Duration <= 0 {
+		return errors.New("promotion: checkInterval must be > 0")
+	}
+
+	if c.SyncParticipationFloor < 0 || c.SyncParticipationFloor > 1 {
+		return errors.New("promotion: syncParticipationFloor must be within [0, 1]")
+	}
+
+	if err := c.Store.Validate(); err != nil {
+		return fmt.Errorf("promotion store: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateRetention refuses to run when the buffer cannot outlive the
+// processing lag: the service reads slots lagEpochs behind head from a buffer
+// the retention reaper empties, so retention must exceed the lag plus at
+// least one epoch of processing margin or promotion silently loses data.
+func (c *Config) ValidateRetention(retention time.Duration) error {
+	if !c.Enabled {
+		return nil
+	}
+
+	epoch := time.Duration(c.SlotsPerEpoch) * c.SecondsPerSlot.Duration //nolint:gosec // bounded by config validation
+
+	required := time.Duration(c.LagEpochs+1) * epoch //nolint:gosec // bounded by config validation
+	if retention < required {
+		return fmt.Errorf(
+			"promotion: beacon state/block retention %s is below lag %d epochs + 1 epoch margin (%s); increase retention or reduce lagEpochs",
+			retention, c.LagEpochs, required,
+		)
+	}
+
+	return nil
+}

--- a/pkg/server/service/promotion/config_test.go
+++ b/pkg/server/service/promotion/config_test.go
@@ -1,0 +1,46 @@
+package promotion
+
+import (
+	"testing"
+	"time"
+
+	"github.com/creasty/defaults"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The zero-value config (promotion absent from yaml) must take defaults and
+// validate: defaults.Set runs at every server startup.
+func TestConfigDefaults(t *testing.T) {
+	conf := &Config{}
+	require.NoError(t, defaults.Set(conf))
+
+	assert.False(t, conf.Enabled)
+	assert.Equal(t, uint64(2), conf.LagEpochs)
+	assert.Equal(t, 30*time.Second, conf.CheckInterval.Duration)
+	assert.Equal(t, uint64(32), conf.SlotsPerEpoch)
+	assert.Equal(t, 12*time.Second, conf.SecondsPerSlot.Duration)
+	assert.Equal(t, uint64(30), conf.RateCapPerHour)
+	assert.Equal(t, uint64(8), conf.BaselineEveryNEpochs)
+	assert.Equal(t, uint64(2), conf.GapTrigger)
+	assert.InDelta(t, 0.95, conf.SyncParticipationFloor, 1e-9)
+
+	// Disabled promotion never blocks startup.
+	require.NoError(t, conf.Validate())
+}
+
+// The service refuses to run when the buffer cannot outlive the processing
+// lag plus one epoch of margin.
+func TestValidateRetention(t *testing.T) {
+	conf := testConfig(t, t.TempDir())
+	require.NoError(t, conf.Validate())
+
+	// lag 2 + 1 margin epochs x 32 slots x 2s = 192s required.
+	assert.Error(t, conf.ValidateRetention(191*time.Second))
+	assert.NoError(t, conf.ValidateRetention(192*time.Second))
+	assert.NoError(t, conf.ValidateRetention(2*time.Hour))
+
+	// Disabled service never blocks startup.
+	conf.Enabled = false
+	assert.NoError(t, conf.ValidateRetention(time.Second))
+}

--- a/pkg/server/service/promotion/config_test.go
+++ b/pkg/server/service/promotion/config_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testEndpoint     = "http://minio:9000"
+	testCorpusBucket = "corpus"
+)
+
 // The zero-value config (promotion absent from yaml) must take defaults and
 // validate: defaults.Set runs at every server startup.
 func TestConfigDefaults(t *testing.T) {
@@ -22,6 +27,7 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Equal(t, 12*time.Second, conf.SecondsPerSlot.Duration)
 	assert.Equal(t, uint64(30), conf.RateCapPerHour)
 	assert.Equal(t, uint64(120), conf.RareCapPerHour)
+	assert.Equal(t, uint64(1000), conf.ReorgCapPerHour)
 	assert.Equal(t, uint64(8), conf.BaselineEveryNEpochs)
 	assert.Equal(t, uint64(2), conf.GapTrigger)
 	assert.InDelta(t, 0.95, conf.SyncParticipationFloor, 1e-9)
@@ -44,4 +50,49 @@ func TestValidateRetention(t *testing.T) {
 	// Disabled service never blocks startup.
 	conf.Enabled = false
 	assert.NoError(t, conf.ValidateRetention(time.Second))
+}
+
+// Manifests publish seconds_per_slot as an integer, so a sub-second value
+// would be published as 0 rather than truncated silently.
+func TestValidateRejectsSubSecondSlots(t *testing.T) {
+	conf := testConfig(t, t.TempDir())
+	conf.SecondsPerSlot.Duration = 500 * time.Millisecond
+
+	assert.Error(t, conf.Validate())
+}
+
+// The corpus outlives every devnet; the buffer is reaped. Pointing both at
+// one destination is never intended, and the failure is otherwise silent.
+func TestValidateDistinctFromBufferStore(t *testing.T) {
+	dir := t.TempDir()
+	conf := testConfig(t, dir)
+
+	same := storeConfig(t, "fs", map[string]string{keyBasePath: dir})
+	other := storeConfig(t, "fs", map[string]string{keyBasePath: t.TempDir()})
+
+	require.Error(t, conf.ValidateDistinctFrom(same))
+	require.NoError(t, conf.ValidateDistinctFrom(other))
+
+	// A different backend is a different destination by construction.
+	s3 := storeConfig(t, "s3", map[string]string{keyBucketName: "buffer", keyEndpoint: testEndpoint})
+	require.NoError(t, conf.ValidateDistinctFrom(s3))
+
+	// Disabled promotion never blocks startup.
+	conf.Enabled = false
+	require.NoError(t, conf.ValidateDistinctFrom(same))
+}
+
+// Two S3 stores are the same destination only when both endpoint and bucket
+// match: one bucket per purpose is the intended layout.
+func TestValidateDistinctFromS3(t *testing.T) {
+	conf := testConfig(t, t.TempDir())
+	conf.Store = storeConfig(t, "s3", map[string]string{keyBucketName: testCorpusBucket, keyEndpoint: testEndpoint})
+
+	sameBucket := storeConfig(t, "s3", map[string]string{keyBucketName: testCorpusBucket, keyEndpoint: testEndpoint})
+	otherBucket := storeConfig(t, "s3", map[string]string{keyBucketName: "buffer", keyEndpoint: testEndpoint})
+	otherEndpoint := storeConfig(t, "s3", map[string]string{keyBucketName: testCorpusBucket, keyEndpoint: "http://other:9000"})
+
+	assert.Error(t, conf.ValidateDistinctFrom(sameBucket))
+	assert.NoError(t, conf.ValidateDistinctFrom(otherBucket))
+	assert.NoError(t, conf.ValidateDistinctFrom(otherEndpoint))
 }

--- a/pkg/server/service/promotion/config_test.go
+++ b/pkg/server/service/promotion/config_test.go
@@ -21,6 +21,7 @@ func TestConfigDefaults(t *testing.T) {
 	assert.Equal(t, uint64(32), conf.SlotsPerEpoch)
 	assert.Equal(t, 12*time.Second, conf.SecondsPerSlot.Duration)
 	assert.Equal(t, uint64(30), conf.RateCapPerHour)
+	assert.Equal(t, uint64(120), conf.RareCapPerHour)
 	assert.Equal(t, uint64(8), conf.BaselineEveryNEpochs)
 	assert.Equal(t, uint64(2), conf.GapTrigger)
 	assert.InDelta(t, 0.95, conf.SyncParticipationFloor, 1e-9)

--- a/pkg/server/service/promotion/corpus.go
+++ b/pkg/server/service/promotion/corpus.go
@@ -1,0 +1,54 @@
+package promotion
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Corpus layout (schema v1). Self-describing; consumable with nothing but an
+// S3 client:
+//
+//	v1/states/<sha256-of-raw-ssz>.ssz                        uncompressed, content-addressed, deduplicated
+//	v1/captures/<network>/<fork>/<capture_id>/input.ssz      the SignedBeaconBlock, raw
+//	v1/captures/<network>/<fork>/<capture_id>/manifest.json
+const (
+	corpusStatePrefix   = "v1/states"
+	corpusCapturePrefix = "v1/captures"
+
+	captureBlockName    = "input.ssz"
+	captureManifestName = "manifest.json"
+
+	captureRootChars = 12
+	networkGVRChars  = 8
+)
+
+func statePath(sha string) string {
+	return fmt.Sprintf("%s/%s.ssz", corpusStatePrefix, sha)
+}
+
+func capturePath(network, fork, captureID, name string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s", corpusCapturePrefix, network, fork, captureID, name)
+}
+
+// captureID is <slot zero-padded to 9>-<block_root hex[0:12]>: lexical order
+// equals slot order, and the root suffix lets both branches of a reorg
+// coexist.
+func captureID(slot uint64, blockRoot string) string {
+	root := strings.TrimPrefix(blockRoot, "0x")
+	if len(root) > captureRootChars {
+		root = root[:captureRootChars]
+	}
+
+	return fmt.Sprintf("%09d-%s", slot, root)
+}
+
+// networkID qualifies the agent-reported network name with the first 4 bytes
+// of the genesis validators root.
+func networkID(configName, gvrHex string) string {
+	gvr := strings.TrimPrefix(gvrHex, "0x")
+	if len(gvr) > networkGVRChars {
+		gvr = gvr[:networkGVRChars]
+	}
+
+	return fmt.Sprintf("%s-%s", configName, gvr)
+}

--- a/pkg/server/service/promotion/corpus.go
+++ b/pkg/server/service/promotion/corpus.go
@@ -20,14 +20,54 @@ const (
 
 	captureRootChars = 12
 	networkGVRChars  = 8
+
+	// unknownComponent stands in for a path component we cannot name
+	// honestly: an unsanitisable network name, or a fork no supported
+	// version decodes.
+	unknownComponent = "unknown"
 )
 
+// safePathComponent keeps a single path segment a single path segment. The
+// network name reaches us from an agent, and the filesystem store resolves
+// "../" the way filesystems do; the corpus layout depends on these being
+// opaque names, not paths. Everything outside the layout's own alphabet
+// becomes an underscore.
+func safePathComponent(s string) string {
+	if s == "" {
+		return unknownComponent
+	}
+
+	out := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+
+	// A component of dots only is "here" or "up one" to a filesystem.
+	if strings.Trim(out, ".") == "" {
+		return unknownComponent
+	}
+
+	return out
+}
+
 func statePath(sha string) string {
-	return fmt.Sprintf("%s/%s.ssz", corpusStatePrefix, sha)
+	return fmt.Sprintf("%s/%s.ssz", corpusStatePrefix, safePathComponent(sha))
 }
 
 func capturePath(network, fork, captureID, name string) string {
-	return fmt.Sprintf("%s/%s/%s/%s/%s", corpusCapturePrefix, network, fork, captureID, name)
+	return fmt.Sprintf("%s/%s/%s/%s/%s",
+		corpusCapturePrefix,
+		safePathComponent(network),
+		safePathComponent(fork),
+		safePathComponent(captureID),
+		name,
+	)
 }
 
 // captureID is <slot zero-padded to 9>-<block_root hex[0:12]>: lexical order
@@ -43,12 +83,14 @@ func captureID(slot uint64, blockRoot string) string {
 }
 
 // networkID qualifies the agent-reported network name with the first 4 bytes
-// of the genesis validators root.
+// of the genesis validators root. The name is sanitised here rather than only
+// at the path layer so that the manifest's network.name and the key it lives
+// under can never disagree.
 func networkID(configName, gvrHex string) string {
 	gvr := strings.TrimPrefix(gvrHex, "0x")
 	if len(gvr) > networkGVRChars {
 		gvr = gvr[:networkGVRChars]
 	}
 
-	return fmt.Sprintf("%s-%s", configName, gvr)
+	return fmt.Sprintf("%s-%s", safePathComponent(configName), gvr)
 }

--- a/pkg/server/service/promotion/fixtures_test.go
+++ b/pkg/server/service/promotion/fixtures_test.go
@@ -1,0 +1,359 @@
+package promotion
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/google/uuid"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ethpandaops/tracoor/pkg/compression"
+	"github.com/ethpandaops/tracoor/pkg/server/persistence"
+	"github.com/ethpandaops/tracoor/pkg/store"
+)
+
+const (
+	testNetwork = "testnet"
+	testNode    = "cl-1-test"
+)
+
+func fillRoot(b byte) phase0.Root {
+	var r phase0.Root
+	for i := range r {
+		r[i] = b
+	}
+
+	return r
+}
+
+// slotRoot derives a deterministic, kind-tagged root for a slot.
+func slotRoot(kind byte, slot uint64) phase0.Root {
+	var r phase0.Root
+
+	r[0] = kind
+	binary.BigEndian.PutUint64(r[1:9], slot)
+
+	return r
+}
+
+func blockRootFor(slot uint64) phase0.Root { return slotRoot(0xbb, slot) }
+func stateRootFor(slot uint64) phase0.Root { return slotRoot(0xaa, slot) }
+
+// testBlock builds a valid altair SignedBeaconBlock and returns its raw SSZ.
+func testBlock(t *testing.T, slot uint64, parentRoot, stateRoot phase0.Root, mutate func(body *altair.BeaconBlockBody)) []byte {
+	t.Helper()
+
+	bits := bitfield.NewBitvector512()
+	for i := uint64(0); i < bits.Len(); i++ {
+		bits.SetBitAt(i, true)
+	}
+
+	block := &altair.SignedBeaconBlock{
+		Message: &altair.BeaconBlock{
+			Slot:          phase0.Slot(slot),
+			ProposerIndex: 1,
+			ParentRoot:    parentRoot,
+			StateRoot:     stateRoot,
+			Body: &altair.BeaconBlockBody{
+				ETH1Data:      &phase0.ETH1Data{BlockHash: make([]byte, 32)},
+				SyncAggregate: &altair.SyncAggregate{SyncCommitteeBits: bits},
+			},
+		},
+	}
+
+	if mutate != nil {
+		mutate(block.Message.Body)
+	}
+
+	raw, err := block.MarshalSSZ()
+	require.NoError(t, err)
+
+	return raw
+}
+
+func withAttesterSlashing(body *altair.BeaconBlockBody) {
+	data := &phase0.AttestationData{
+		BeaconBlockRoot: fillRoot(0x01),
+		Source:          &phase0.Checkpoint{Root: fillRoot(0x02)},
+		Target:          &phase0.Checkpoint{Root: fillRoot(0x03)},
+	}
+	attestation := &phase0.IndexedAttestation{AttestingIndices: []uint64{1}, Data: data}
+	body.AttesterSlashings = []*phase0.AttesterSlashing{{Attestation1: attestation, Attestation2: attestation}}
+}
+
+func withSparseSyncBits(body *altair.BeaconBlockBody) {
+	bits := bitfield.NewBitvector512()
+	for i := uint64(0); i < 100; i++ {
+		bits.SetBitAt(i, true)
+	}
+
+	body.SyncAggregate.SyncCommitteeBits = bits
+}
+
+// testState builds bytes that satisfy the BeaconState fixed prefix; the
+// promotion service never decodes states, so the tail is filler.
+func testState(gvr phase0.Root, slot uint64) []byte {
+	buf := make([]byte, 128)
+	binary.LittleEndian.PutUint64(buf[0:8], 1700000000)
+	copy(buf[8:40], gvr[:])
+	binary.LittleEndian.PutUint64(buf[40:48], slot)
+
+	for i := 48; i < len(buf); i++ {
+		buf[i] = 0x42
+	}
+
+	return buf
+}
+
+func gzipped(t *testing.T, raw []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write(raw)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
+}
+
+type env struct {
+	t         *testing.T
+	conf      *Config
+	db        *persistence.Indexer
+	buffer    store.Store
+	corpusDir string
+	promoter  *Promoter
+}
+
+func newEnv(t *testing.T, mutate func(*Config)) *env {
+	t.Helper()
+
+	ctx := t.Context()
+
+	db, _, err := persistence.NewMockIndexer()
+	require.NoError(t, err)
+
+	buffer, err := store.NewFSStore("promotion_test", logrus.New(), &store.FSStoreConfig{BasePath: t.TempDir()}, store.DefaultOptions().SetMetricsEnabled(false))
+	require.NoError(t, err)
+
+	corpusDir := t.TempDir()
+	conf := testConfig(t, corpusDir)
+
+	if mutate != nil {
+		mutate(conf)
+	}
+
+	promoter, err := NewPromoter(ctx, logrus.New(), conf, db, buffer)
+	require.NoError(t, err)
+
+	return &env{t: t, conf: conf, db: db, buffer: buffer, corpusDir: corpusDir, promoter: promoter}
+}
+
+// restart replaces the promoter with a fresh instance sharing the same DB and
+// stores, simulating a service restart with no persistent cursor.
+func (e *env) restart() {
+	e.t.Helper()
+
+	promoter, err := NewPromoter(e.t.Context(), logrus.New(), e.conf, e.db, e.buffer)
+	require.NoError(e.t, err)
+
+	e.promoter = promoter
+}
+
+func testConfig(t *testing.T, corpusDir string) *Config {
+	t.Helper()
+
+	doc := fmt.Sprintf(`
+enabled: true
+lagEpochs: 2
+checkInterval: 30s
+slotsPerEpoch: 32
+secondsPerSlot: 2s
+rateCapPerHour: 1000
+baselineEveryNEpochs: 8
+gapTrigger: 2
+syncParticipationFloor: 0.95
+store:
+  type: fs
+  config:
+    base_path: %s
+`, corpusDir)
+
+	conf := &Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(doc), conf))
+
+	return conf
+}
+
+func (e *env) insertBlockRow(node string, slot, epoch uint64, rootHex, location string, fetchedAt time.Time) {
+	e.t.Helper()
+
+	require.NoError(e.t, e.db.InsertBeaconBlock(e.t.Context(), &persistence.BeaconBlock{
+		ID:                   uuid.New().String(),
+		Node:                 node,
+		Slot:                 int64(slot),
+		Epoch:                int64(epoch),
+		BlockRoot:            rootHex,
+		FetchedAt:            fetchedAt,
+		ContentEncoding:      compression.Gzip.ContentEncoding,
+		Location:             location,
+		Network:              testNetwork,
+		BeaconImplementation: "test",
+		NodeVersion:          "test",
+	}))
+}
+
+func (e *env) seedBlock(node string, slot, epoch uint64, root phase0.Root, raw []byte, fetchedAt time.Time) {
+	e.t.Helper()
+
+	rootHex := root.String()
+	location := fmt.Sprintf("beacon_blocks/%s/%d/%s/%s", testNetwork, slot, node, rootHex)
+	compressed := gzipped(e.t, raw)
+
+	_, err := e.buffer.SaveBeaconBlock(e.t.Context(), &store.SaveParams{Data: &compressed, Location: location, ContentEncoding: compression.Gzip.ContentEncoding})
+	require.NoError(e.t, err)
+
+	e.insertBlockRow(node, slot, epoch, rootHex, location, fetchedAt)
+}
+
+func (e *env) seedState(node string, slot uint64, stateRoot phase0.Root, raw []byte, fetchedAt time.Time) {
+	e.t.Helper()
+
+	location := fmt.Sprintf("beacon_states/%s/%d/%s/%s", testNetwork, slot, node, stateRoot.String())
+	compressed := gzipped(e.t, raw)
+
+	_, err := e.buffer.SaveBeaconState(e.t.Context(), &store.SaveParams{Data: &compressed, Location: location, ContentEncoding: compression.Gzip.ContentEncoding})
+	require.NoError(e.t, err)
+
+	require.NoError(e.t, e.db.InsertBeaconState(e.t.Context(), &persistence.BeaconState{
+		ID:                   uuid.New().String(),
+		Node:                 node,
+		Slot:                 int64(slot),
+		Epoch:                int64(slot / 32),
+		StateRoot:            stateRoot.String(),
+		FetchedAt:            fetchedAt,
+		ContentEncoding:      compression.Gzip.ContentEncoding,
+		Location:             location,
+		Network:              testNetwork,
+		BeaconImplementation: "test",
+		NodeVersion:          "test",
+	}))
+}
+
+// seedChain seeds a linear chain of blocks at the given slots (each pointing
+// at the previous via parent_root) with a matching post-state per slot.
+// Returns the raw block bytes per slot.
+func (e *env) seedChain(gvr phase0.Root, slots ...uint64) map[uint64][]byte {
+	e.t.Helper()
+
+	raws := make(map[uint64][]byte, len(slots))
+	now := time.Now()
+
+	for i, slot := range slots {
+		parent := blockRootFor(slot - 1)
+		if i > 0 {
+			parent = blockRootFor(slots[i-1])
+		}
+
+		raw := testBlock(e.t, slot, parent, stateRootFor(slot), nil)
+		raws[slot] = raw
+
+		e.seedBlock(testNode, slot, slot/32, blockRootFor(slot), raw, now)
+		e.seedState(testNode, slot, stateRootFor(slot), testState(gvr, slot), now)
+	}
+
+	return raws
+}
+
+// seedHeadAnchor seeds a head block so that target = headEpoch - lagEpochs.
+func (e *env) seedHeadAnchor(slot uint64) {
+	e.t.Helper()
+
+	raw := testBlock(e.t, slot, blockRootFor(slot-1), stateRootFor(slot), nil)
+	e.seedBlock(testNode, slot, slot/32, blockRootFor(slot), raw, time.Now())
+}
+
+// corpusFiles returns relative path -> sha256 of every object in the corpus.
+func (e *env) corpusFiles() map[string]string {
+	e.t.Helper()
+
+	files := map[string]string{}
+
+	err := filepath.WalkDir(e.corpusDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		rel, relErr := filepath.Rel(e.corpusDir, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		files[filepath.ToSlash(rel)] = sha256Hex(data)
+
+		return nil
+	})
+	require.NoError(e.t, err)
+
+	return files
+}
+
+func (e *env) findManifests() []string {
+	e.t.Helper()
+
+	manifests := []string{}
+
+	for path := range e.corpusFiles() {
+		if strings.HasSuffix(path, captureManifestName) {
+			manifests = append(manifests, path)
+		}
+	}
+
+	return manifests
+}
+
+func (e *env) readManifest(path string) *Manifest {
+	e.t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(e.corpusDir, filepath.FromSlash(path)))
+	require.NoError(e.t, err)
+
+	manifest := &Manifest{}
+	require.NoError(e.t, json.Unmarshal(data, manifest))
+
+	return manifest
+}
+
+func (e *env) readCorpusObject(path string) []byte {
+	e.t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(e.corpusDir, filepath.FromSlash(path)))
+	require.NoError(e.t, err)
+
+	return data
+}

--- a/pkg/server/service/promotion/fixtures_test.go
+++ b/pkg/server/service/promotion/fixtures_test.go
@@ -187,6 +187,7 @@ checkInterval: 30s
 slotsPerEpoch: 32
 secondsPerSlot: 2s
 rateCapPerHour: 1000
+rareCapPerHour: 120
 baselineEveryNEpochs: 8
 gapTrigger: 2
 syncParticipationFloor: 0.95

--- a/pkg/server/service/promotion/fixtures_test.go
+++ b/pkg/server/service/promotion/fixtures_test.go
@@ -29,6 +29,7 @@ import (
 const (
 	testNetwork = "testnet"
 	testNode    = "cl-1-test"
+	testMeta    = "test"
 )
 
 func fillRoot(b byte) phase0.Root {
@@ -58,7 +59,7 @@ func testBlock(t *testing.T, slot uint64, parentRoot, stateRoot phase0.Root, mut
 	t.Helper()
 
 	bits := bitfield.NewBitvector512()
-	for i := uint64(0); i < bits.Len(); i++ {
+	for i := range bits.Len() {
 		bits.SetBitAt(i, true)
 	}
 
@@ -97,7 +98,7 @@ func withAttesterSlashing(body *altair.BeaconBlockBody) {
 
 func withSparseSyncBits(body *altair.BeaconBlockBody) {
 	bits := bitfield.NewBitvector512()
-	for i := uint64(0); i < 100; i++ {
+	for i := range uint64(100) {
 		bits.SetBitAt(i, true)
 	}
 
@@ -214,8 +215,8 @@ func (e *env) insertBlockRow(node string, slot, epoch uint64, rootHex, location 
 		ContentEncoding:      compression.Gzip.ContentEncoding,
 		Location:             location,
 		Network:              testNetwork,
-		BeaconImplementation: "test",
-		NodeVersion:          "test",
+		BeaconImplementation: testMeta,
+		NodeVersion:          testMeta,
 	}))
 }
 
@@ -251,8 +252,8 @@ func (e *env) seedState(node string, slot uint64, stateRoot phase0.Root, raw []b
 		ContentEncoding:      compression.Gzip.ContentEncoding,
 		Location:             location,
 		Network:              testNetwork,
-		BeaconImplementation: "test",
-		NodeVersion:          "test",
+		BeaconImplementation: testMeta,
+		NodeVersion:          testMeta,
 	}))
 }
 

--- a/pkg/server/service/promotion/fixtures_test.go
+++ b/pkg/server/service/promotion/fixtures_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/creasty/defaults"
 	"github.com/google/uuid"
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/sirupsen/logrus"
@@ -197,8 +198,27 @@ store:
     base_path: %s
 `, corpusDir)
 
+	// Defaults first, then the document - exactly the order the server uses,
+	// so a field the document omits behaves in tests as it will in prod.
 	conf := &Config{}
+	require.NoError(t, defaults.Set(conf))
 	require.NoError(t, yaml.Unmarshal([]byte(doc), conf))
+
+	return conf
+}
+
+// storeConfig builds a store.Config the way yaml loading would, so the raw
+// message behind it is a real unmarshaller rather than a zero value.
+func storeConfig(t *testing.T, storeType string, config map[string]string) store.Config {
+	t.Helper()
+
+	doc := fmt.Sprintf("type: %s\nconfig:\n", storeType)
+	for key, value := range config {
+		doc += fmt.Sprintf("  %s: %q\n", key, value)
+	}
+
+	conf := store.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &conf))
 
 	return conf
 }
@@ -349,6 +369,47 @@ func (e *env) readManifest(path string) *Manifest {
 	require.NoError(e.t, json.Unmarshal(data, manifest))
 
 	return manifest
+}
+
+// purge removes every indexed block and state for the test network, standing
+// in for the retention reaper.
+func (e *env) purge() {
+	e.t.Helper()
+
+	blocks, err := e.db.ListBeaconBlock(e.t.Context(), &persistence.BeaconBlockFilter{Network: ptr(testNetwork)}, &persistence.PaginationCursor{Limit: 10000, OrderBy: "slot ASC"})
+	require.NoError(e.t, err)
+
+	for _, row := range blocks {
+		require.NoError(e.t, e.db.RemoveBeaconBlock(e.t.Context(), row.ID))
+	}
+
+	states, err := e.db.ListBeaconState(e.t.Context(), &persistence.BeaconStateFilter{Network: ptr(testNetwork)}, &persistence.PaginationCursor{Limit: 10000, OrderBy: "slot ASC"})
+	require.NoError(e.t, err)
+
+	for _, row := range states {
+		require.NoError(e.t, e.db.RemoveBeaconState(e.t.Context(), row.ID))
+	}
+}
+
+// expireIdentity ages out the cached genesis validators root so the next tick
+// re-resolves it.
+func (e *env) expireIdentity() {
+	e.t.Helper()
+
+	e.promoter.network(testNetwork).gvrResolved = time.Now().Add(-2 * networkIdentityTTL)
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// requireWriteProtectable skips a test that relies on a read-only directory
+// actually blocking writes. Root ignores the mode bits, and the test would
+// then assert nothing at all.
+func requireWriteProtectable(t *testing.T) {
+	t.Helper()
+
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: read-only directories do not block writes")
+	}
 }
 
 func (e *env) readCorpusObject(path string) []byte {

--- a/pkg/server/service/promotion/manifest.go
+++ b/pkg/server/service/promotion/manifest.go
@@ -1,0 +1,95 @@
+package promotion
+
+import "time"
+
+// manifestSchema is the manifest schema version.
+const manifestSchema = 1
+
+// Branch labels for the promotion.branch manifest field.
+const (
+	BranchCanonical = "canonical"
+	BranchOrphaned  = "orphaned"
+)
+
+// Manifest is the claims-as-of-promotion-time record written next to every
+// promoted capture. Corrections are additive or omitted, never in-place: a
+// wrong label poisons downstream consumers, a missing one is honest.
+//
+//nolint:tagliatelle // the manifest schema is snake_case by design; it is a consumer-facing contract.
+type Manifest struct {
+	Schema     int               `json:"schema"`
+	Tool       string            `json:"tool"`
+	PromotedAt time.Time         `json:"promoted_at"`
+	Network    ManifestNetwork   `json:"network"`
+	Fork       ManifestFork      `json:"fork"`
+	Block      ManifestBlock     `json:"block"`
+	Prestate   *ManifestPrestate `json:"prestate,omitempty"`
+	Promotion  ManifestPromotion `json:"promotion"`
+	Context    ManifestContext   `json:"context"`
+}
+
+//nolint:tagliatelle // see Manifest.
+type ManifestNetwork struct {
+	// Name qualifies the config name with the genesis validators root:
+	// devnets are torn down and recreated under the same name constantly,
+	// and the GVR prefix is the only stable, cheap disambiguator.
+	Name                  string `json:"name"`
+	ConfigName            string `json:"config_name"`
+	GenesisValidatorsRoot string `json:"genesis_validators_root"`
+	SlotsPerEpoch         uint64 `json:"slots_per_epoch"`
+	SecondsPerSlot        uint64 `json:"seconds_per_slot"`
+}
+
+type ManifestFork struct {
+	// Name is the decoded fork name, or "unknown" when no supported fork
+	// decodes the block.
+	Name string `json:"name"`
+}
+
+//nolint:tagliatelle // see Manifest.
+type ManifestBlock struct {
+	Slot       uint64 `json:"slot"`
+	Root       string `json:"root"`
+	ParentRoot string `json:"parent_root"`
+	StateRoot  string `json:"state_root"`
+	// SHA256 is computed over exactly the raw (decompressed) bytes written.
+	SHA256 string `json:"sha256"`
+	Size   int    `json:"size"`
+}
+
+//nolint:tagliatelle // see Manifest.
+type ManifestPrestate struct {
+	Slot uint64 `json:"slot"`
+	// SHA256 doubles as the state's object name under v1/states/.
+	SHA256 string `json:"sha256"`
+	Size   int    `json:"size"`
+	// ExpectedStateRoot is the PARENT block's own state_root field, read
+	// from the parent's bytes - keyed by parent_root, therefore
+	// branch-exact. Any consumer with an SSZ library can verify
+	// hash_tree_root(state) == expected_state_root forever, without
+	// tracoor. Omitted rather than substituted when the parent block is
+	// missing from the buffer.
+	ExpectedStateRoot string `json:"expected_state_root,omitempty"`
+	SourceNode        string `json:"source_node"`
+}
+
+//nolint:tagliatelle // see Manifest.
+type ManifestPromotion struct {
+	Triggers []string `json:"triggers"`
+	Decoded  bool     `json:"decoded"`
+	// PairVerified is false when the pairing claim is unproven (missing
+	// data, undecodable fork); both artifacts are still individually real.
+	PairVerified bool   `json:"pair_verified"`
+	Branch       string `json:"branch"`
+	LagEpochs    uint64 `json:"lag_epochs"`
+}
+
+// ManifestContext records network-wide conditions as context, never as
+// per-slot triggers. The server side has no beacon connection, so unlike the
+// prototype it records only what the index can prove; finality fields are
+// deliberately absent rather than fabricated.
+//
+//nolint:tagliatelle // see Manifest.
+type ManifestContext struct {
+	HeadSlotAtPromotion uint64 `json:"head_slot_at_promotion"`
+}

--- a/pkg/server/service/promotion/metrics.go
+++ b/pkg/server/service/promotion/metrics.go
@@ -19,11 +19,12 @@ type Metrics struct {
 // Skip reasons. Every non-promotion of a candidate that fired a trigger is
 // visible, never silent.
 const (
-	SkipReasonRateCapped      = "rate_capped"
-	SkipReasonMissingObject   = "missing_object"
-	SkipReasonMalformed       = "malformed"
-	SkipReasonGVRAmbiguous    = "gvr_ambiguous"
-	SkipReasonAlreadyPromoted = "already_promoted"
+	SkipReasonRateCappedCommon = "rate_capped_common"
+	SkipReasonRateCappedRare   = "rate_capped_rare"
+	SkipReasonMissingObject    = "missing_object"
+	SkipReasonMalformed        = "malformed"
+	SkipReasonGVRAmbiguous     = "gvr_ambiguous"
+	SkipReasonAlreadyPromoted  = "already_promoted"
 )
 
 var (

--- a/pkg/server/service/promotion/metrics.go
+++ b/pkg/server/service/promotion/metrics.go
@@ -13,6 +13,7 @@ type Metrics struct {
 	skips              *prometheus.CounterVec
 	errors             *prometheus.CounterVec
 	corpusBytes        *prometheus.CounterVec
+	networkResets      *prometheus.CounterVec
 	lastProcessedEpoch *prometheus.GaugeVec
 }
 
@@ -21,10 +22,19 @@ type Metrics struct {
 const (
 	SkipReasonRateCappedCommon = "rate_capped_common"
 	SkipReasonRateCappedRare   = "rate_capped_rare"
+	SkipReasonRateCappedReorg  = "rate_capped_reorg"
 	SkipReasonMissingObject    = "missing_object"
 	SkipReasonMalformed        = "malformed"
 	SkipReasonGVRAmbiguous     = "gvr_ambiguous"
 	SkipReasonAlreadyPromoted  = "already_promoted"
+	SkipReasonRowLimit         = "row_limit_truncated"
+	SkipReasonImplausibleEpoch = "implausible_head_epoch"
+)
+
+// Reasons a network's per-process state was discarded and rebuilt.
+const (
+	ResetReasonHeightRegression = "height_regression"
+	ResetReasonIdentityChange   = "identity_change"
 )
 
 var (
@@ -34,15 +44,15 @@ var (
 
 // GetMetricsInstance returns the process-wide promotion metrics, registering
 // them at most once so multiple service instances (restarts, tests) are safe.
-func GetMetricsInstance(namespace string, enabled bool) *Metrics {
+func GetMetricsInstance(namespace string) *Metrics {
 	metricsOnce.Do(func() {
-		metricsInstance = newMetrics(namespace, enabled)
+		metricsInstance = newMetrics(namespace)
 	})
 
 	return metricsInstance
 }
 
-func newMetrics(namespace string, enabled bool) *Metrics {
+func newMetrics(namespace string) *Metrics {
 	m := &Metrics{
 		promotions: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
@@ -74,6 +84,11 @@ func newMetrics(namespace string, enabled bool) *Metrics {
 			Name:      "corpus_bytes_total",
 			Help:      "Bytes written to the corpus store.",
 		}, []string{labelNetwork, "kind"}),
+		networkResets: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "network_resets_total",
+			Help:      "Number of times a network's promotion cursor and identity were discarded and rebuilt.",
+		}, []string{labelNetwork, "reason"}),
 		lastProcessedEpoch: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "last_processed_epoch",
@@ -81,17 +96,16 @@ func newMetrics(namespace string, enabled bool) *Metrics {
 		}, []string{labelNetwork}),
 	}
 
-	if enabled {
-		prometheus.MustRegister(
-			m.promotions,
-			m.captures,
-			m.unpaired,
-			m.skips,
-			m.errors,
-			m.corpusBytes,
-			m.lastProcessedEpoch,
-		)
-	}
+	prometheus.MustRegister(
+		m.promotions,
+		m.captures,
+		m.unpaired,
+		m.skips,
+		m.errors,
+		m.corpusBytes,
+		m.networkResets,
+		m.lastProcessedEpoch,
+	)
 
 	return m
 }
@@ -118,6 +132,10 @@ func (m *Metrics) ObserveError(network string) {
 
 func (m *Metrics) ObserveCorpusBytes(network, kind string, n int) {
 	m.corpusBytes.WithLabelValues(network, kind).Add(float64(n))
+}
+
+func (m *Metrics) ObserveNetworkReset(network, reason string) {
+	m.networkResets.WithLabelValues(network, reason).Inc()
 }
 
 func (m *Metrics) ObserveLastProcessedEpoch(network string, epoch uint64) {

--- a/pkg/server/service/promotion/metrics.go
+++ b/pkg/server/service/promotion/metrics.go
@@ -1,0 +1,124 @@
+package promotion
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	promotions         *prometheus.CounterVec
+	captures           *prometheus.CounterVec
+	unpaired           *prometheus.CounterVec
+	skips              *prometheus.CounterVec
+	errors             *prometheus.CounterVec
+	corpusBytes        *prometheus.CounterVec
+	lastProcessedEpoch *prometheus.GaugeVec
+}
+
+// Skip reasons. Every non-promotion of a candidate that fired a trigger is
+// visible, never silent.
+const (
+	SkipReasonRateCapped      = "rate_capped"
+	SkipReasonMissingObject   = "missing_object"
+	SkipReasonMalformed       = "malformed"
+	SkipReasonGVRAmbiguous    = "gvr_ambiguous"
+	SkipReasonAlreadyPromoted = "already_promoted"
+)
+
+var (
+	metricsInstance *Metrics
+	metricsOnce     sync.Once
+)
+
+// GetMetricsInstance returns the process-wide promotion metrics, registering
+// them at most once so multiple service instances (restarts, tests) are safe.
+func GetMetricsInstance(namespace string, enabled bool) *Metrics {
+	metricsOnce.Do(func() {
+		metricsInstance = newMetrics(namespace, enabled)
+	})
+
+	return metricsInstance
+}
+
+func newMetrics(namespace string, enabled bool) *Metrics {
+	m := &Metrics{
+		promotions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "promotions_total",
+			Help:      "Number of promotions per trigger (a capture with N triggers counts N times).",
+		}, []string{"network", "trigger"}),
+		captures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "captures_total",
+			Help:      "Number of captures written to the corpus.",
+		}, []string{"network", "branch"}),
+		unpaired: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "unpaired_captures_total",
+			Help:      "Number of captures promoted without a pre-state (buffer holes).",
+		}, []string{"network"}),
+		skips: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "skips_total",
+			Help:      "Number of triggered candidates skipped instead of promoted.",
+		}, []string{"network", "reason"}),
+		errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "errors_total",
+			Help:      "Number of errors while processing candidates.",
+		}, []string{"network"}),
+		corpusBytes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "corpus_bytes_total",
+			Help:      "Bytes written to the corpus store.",
+		}, []string{"network", "kind"}),
+		lastProcessedEpoch: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "last_processed_epoch",
+			Help:      "Highest epoch processed per network.",
+		}, []string{"network"}),
+	}
+
+	if enabled {
+		prometheus.MustRegister(
+			m.promotions,
+			m.captures,
+			m.unpaired,
+			m.skips,
+			m.errors,
+			m.corpusBytes,
+			m.lastProcessedEpoch,
+		)
+	}
+
+	return m
+}
+
+func (m *Metrics) ObserveTrigger(network, trigger string) {
+	m.promotions.WithLabelValues(network, trigger).Inc()
+}
+
+func (m *Metrics) ObserveCapture(network, branch string) {
+	m.captures.WithLabelValues(network, branch).Inc()
+}
+
+func (m *Metrics) ObserveUnpaired(network string) {
+	m.unpaired.WithLabelValues(network).Inc()
+}
+
+func (m *Metrics) ObserveSkip(network, reason string) {
+	m.skips.WithLabelValues(network, reason).Inc()
+}
+
+func (m *Metrics) ObserveError(network string) {
+	m.errors.WithLabelValues(network).Inc()
+}
+
+func (m *Metrics) ObserveCorpusBytes(network, kind string, n int) {
+	m.corpusBytes.WithLabelValues(network, kind).Add(float64(n))
+}
+
+func (m *Metrics) ObserveLastProcessedEpoch(network string, epoch uint64) {
+	m.lastProcessedEpoch.WithLabelValues(network).Set(float64(epoch))
+}

--- a/pkg/server/service/promotion/metrics.go
+++ b/pkg/server/service/promotion/metrics.go
@@ -47,37 +47,37 @@ func newMetrics(namespace string, enabled bool) *Metrics {
 			Namespace: namespace,
 			Name:      "promotions_total",
 			Help:      "Number of promotions per trigger (a capture with N triggers counts N times).",
-		}, []string{"network", "trigger"}),
+		}, []string{labelNetwork, "trigger"}),
 		captures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "captures_total",
 			Help:      "Number of captures written to the corpus.",
-		}, []string{"network", "branch"}),
+		}, []string{labelNetwork, "branch"}),
 		unpaired: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "unpaired_captures_total",
 			Help:      "Number of captures promoted without a pre-state (buffer holes).",
-		}, []string{"network"}),
+		}, []string{labelNetwork}),
 		skips: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "skips_total",
 			Help:      "Number of triggered candidates skipped instead of promoted.",
-		}, []string{"network", "reason"}),
+		}, []string{labelNetwork, "reason"}),
 		errors: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "errors_total",
 			Help:      "Number of errors while processing candidates.",
-		}, []string{"network"}),
+		}, []string{labelNetwork}),
 		corpusBytes: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "corpus_bytes_total",
 			Help:      "Bytes written to the corpus store.",
-		}, []string{"network", "kind"}),
+		}, []string{labelNetwork, "kind"}),
 		lastProcessedEpoch: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "last_processed_epoch",
 			Help:      "Highest epoch processed per network.",
-		}, []string{"network"}),
+		}, []string{labelNetwork}),
 	}
 
 	if enabled {

--- a/pkg/server/service/promotion/promotion.go
+++ b/pkg/server/service/promotion/promotion.go
@@ -48,6 +48,15 @@ const (
 	// epochRowLimit bounds a single epoch listing; 32-ish slots times a
 	// handful of nodes sits far below it.
 	epochRowLimit = 10000
+
+	// maxEpochAttempts bounds how often a failing epoch is retried before
+	// the service abandons it and moves on.
+	maxEpochAttempts = 10
+
+	// Shared log-field and metric-label keys.
+	labelNetwork   = "network"
+	labelSlot      = "slot"
+	labelBlockRoot = "block_root"
 )
 
 // Promoter is the promotion service. All mutable state is owned by the single
@@ -72,6 +81,11 @@ type Promoter struct {
 
 	rate map[string]*rateWindow
 
+	// retries bounds how often a failing epoch is retried before the
+	// service advances past it: only the first failing epoch per network
+	// can block, so a single entry per network suffices.
+	retries map[string]*epochRetry
+
 	done     chan struct{}
 	stopOnce sync.Once
 }
@@ -79,6 +93,11 @@ type Promoter struct {
 type rateWindow struct {
 	start time.Time
 	count uint64
+}
+
+type epochRetry struct {
+	epoch    uint64
+	attempts int
 }
 
 // NewPromoter creates the promotion service. The corpus store is built from
@@ -103,6 +122,7 @@ func NewPromoter(ctx context.Context, log logrus.FieldLogger, conf *Config, db *
 		lastProcessedEpoch: make(map[string]uint64),
 		networkGVR:         make(map[string]string),
 		rate:               make(map[string]*rateWindow),
+		retries:            make(map[string]*epochRetry),
 		done:               make(chan struct{}),
 	}, nil
 }
@@ -155,7 +175,7 @@ func (p *Promoter) run(ctx context.Context) {
 }
 
 func (p *Promoter) tick(ctx context.Context) {
-	values, err := p.db.DistinctBeaconBlockValues(ctx, []string{"network"})
+	values, err := p.db.DistinctBeaconBlockValues(ctx, []string{labelNetwork})
 	if err != nil {
 		p.log.WithError(err).Error("Failed to list networks")
 
@@ -169,7 +189,7 @@ func (p *Promoter) tick(ctx context.Context) {
 
 		if err := p.processNetwork(ctx, network); err != nil {
 			p.metrics.ObserveError(network)
-			p.log.WithError(err).WithField("network", network).Error("Failed to process network")
+			p.log.WithError(err).WithField(labelNetwork, network).Error("Failed to process network")
 		}
 	}
 }
@@ -201,11 +221,26 @@ func (p *Promoter) processNetwork(ctx context.Context, network string) error {
 
 	for epoch := from; epoch <= target; epoch++ {
 		if err := p.processEpoch(ctx, network, epoch, headSlot); err != nil {
-			// Do not advance past a failing epoch; retry next tick. The
-			// retention reaper bounds how long that can go on, and the
-			// error metric makes the loss visible, never silent.
-			return errors.Wrapf(err, "failed to process epoch %d", epoch)
+			// Hold the epoch back and retry next tick - the existence
+			// probe makes re-processing free - but only boundedly: a
+			// deterministic poison candidate must not block every later
+			// epoch until the reaper eats them.
+			retry := p.retries[network]
+			if retry == nil || retry.epoch != epoch {
+				retry = &epochRetry{epoch: epoch}
+				p.retries[network] = retry
+			}
+
+			retry.attempts++
+			if retry.attempts < maxEpochAttempts {
+				return errors.Wrapf(err, "failed to process epoch %d (attempt %d/%d)", epoch, retry.attempts, maxEpochAttempts)
+			}
+
+			p.log.WithError(err).WithFields(logrus.Fields{labelNetwork: network, "epoch": epoch}).Error("Abandoning epoch after repeated failures; its unpromoted captures are lost")
+			p.metrics.ObserveError(network)
 		}
+
+		delete(p.retries, network)
 
 		p.lastProcessedEpoch[network] = epoch
 		p.metrics.ObserveLastProcessedEpoch(network, epoch)
@@ -275,6 +310,8 @@ func (p *Promoter) processEpoch(ctx context.Context, network string, epoch, head
 
 	baselineSlot, haveBaseline := p.baselineSlot(pass)
 
+	var failed error
+
 	for _, slot := range pass.slots {
 		cands := pass.bySlot[slot]
 		isReorg := len(cands) > 1
@@ -290,12 +327,17 @@ func (p *Promoter) processEpoch(ctx context.Context, network string, epoch, head
 
 			if err := p.promote(ctx, pass, cand, parent, triggers, branches[cand.root]); err != nil {
 				p.metrics.ObserveError(network)
-				p.log.WithError(err).WithFields(logrus.Fields{"network": network, "slot": slot, "block_root": cand.root}).Error("Failed to promote candidate")
+				p.log.WithError(err).WithFields(logrus.Fields{labelNetwork: network, labelSlot: slot, labelBlockRoot: cand.root}).Error("Failed to promote candidate")
+
+				// Hold the epoch back so the capture is retried next tick;
+				// the existence probe makes re-processing free, and the
+				// retention window bounds how long a retry can matter.
+				failed = err
 			}
 		}
 	}
 
-	return nil
+	return failed
 }
 
 // buildCandidates fetches every distinct root's bytes once and byte-peeks the
@@ -364,7 +406,7 @@ func (p *Promoter) loadCandidate(ctx context.Context, network string, cand *cand
 			// Truncated or misfiled: promote nothing under a label the
 			// payload contradicts.
 			p.metrics.ObserveSkip(network, SkipReasonMalformed)
-			p.log.WithError(err).WithFields(logrus.Fields{"location": row.Location, "slot": cand.slot}).Warn("Block bytes fail sanity rules")
+			p.log.WithError(err).WithFields(logrus.Fields{"location": row.Location, labelSlot: cand.slot}).Warn("Block bytes fail sanity rules")
 
 			continue
 		}
@@ -613,7 +655,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 	// consumed once the capture is known to be new.
 	if !bypassCap && !p.headroom(pass.network) {
 		p.metrics.ObserveSkip(pass.network, SkipReasonRateCapped)
-		p.log.WithFields(logrus.Fields{"network": pass.network, "slot": cand.slot, "block_root": cand.root}).Debug("Rate cap exhausted, skipping promotion")
+		p.log.WithFields(logrus.Fields{labelNetwork: pass.network, labelSlot: cand.slot, labelBlockRoot: cand.root}).Debug("Rate cap exhausted, skipping promotion")
 
 		return nil
 	}
@@ -646,7 +688,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 		gvr = p.resolveNetworkGVR(ctx, pass.network)
 		if gvr == "" {
 			p.metrics.ObserveSkip(pass.network, SkipReasonGVRAmbiguous)
-			p.log.WithFields(logrus.Fields{"network": pass.network, "slot": cand.slot}).Warn("No genesis validators root resolvable; refusing to label capture")
+			p.log.WithFields(logrus.Fields{labelNetwork: pass.network, labelSlot: cand.slot}).Warn("No genesis validators root resolvable; refusing to label capture")
 
 			return nil
 		}
@@ -667,10 +709,6 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 
 			return nil
 		}
-	}
-
-	if !bypassCap {
-		p.consume(pass.network)
 	}
 
 	if stateRaw != nil {
@@ -732,6 +770,13 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 		return errors.Wrap(err, "failed to write manifest")
 	}
 
+	// The manifest is the commit point: budget is only consumed once the
+	// capture actually landed, so a corpus-store outage cannot burn the
+	// hourly window on failed writes.
+	if !bypassCap {
+		p.consume(pass.network)
+	}
+
 	p.metrics.ObserveCorpusBytes(pass.network, "manifest", len(data))
 	p.metrics.ObserveCapture(pass.network, branch)
 
@@ -744,9 +789,9 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 	}
 
 	p.log.WithFields(logrus.Fields{
-		"network":       network,
-		"slot":          cand.slot,
-		"block_root":    cand.root,
+		labelNetwork:    network,
+		labelSlot:       cand.slot,
+		labelBlockRoot:  cand.root,
 		"triggers":      triggers,
 		"branch":        branch,
 		"pair_verified": manifest.Promotion.PairVerified,

--- a/pkg/server/service/promotion/promotion.go
+++ b/pkg/server/service/promotion/promotion.go
@@ -91,8 +91,9 @@ type Promoter struct {
 }
 
 type rateWindow struct {
-	start time.Time
-	count uint64
+	start       time.Time
+	commonCount uint64
+	rareCount   uint64
 }
 
 type epochRetry struct {
@@ -603,9 +604,36 @@ func (p *Promoter) lookaheadChildren(ctx context.Context, pass *epochPass) map[s
 	return out
 }
 
-// headroom reports whether the per-network hourly window has budget left,
-// without consuming any.
-func (p *Promoter) headroom(network string) bool {
+// rateTier classifies a capture for admission. Reorgs are uncapped: they are
+// self-limiting per slot and the orphaned branch is unobtainable anywhere
+// else. Rare-but-not-bounded classes (slashings can arrive by the hundreds
+// in a mass-slashing incident) get their own budget so they never compete
+// with a participation/gap flood, yet keep a hard ceiling. Everything
+// repetitive or spammable draws from the common budget.
+type rateTier int
+
+const (
+	tierUncapped rateTier = iota
+	tierRare
+	tierCommon
+)
+
+func classifyTier(triggers []string) rateTier {
+	if slices.Contains(triggers, TriggerReorg) {
+		return tierUncapped
+	}
+
+	for _, trigger := range triggers {
+		switch trigger {
+		case TriggerSlashing, TriggerVoluntaryExit, TriggerBLSToExecutionChange, TriggerForkBoundary:
+			return tierRare
+		}
+	}
+
+	return tierCommon
+}
+
+func (p *Promoter) window(network string) *rateWindow {
 	now := time.Now()
 
 	w := p.rate[network]
@@ -614,13 +642,34 @@ func (p *Promoter) headroom(network string) bool {
 		p.rate[network] = w
 	}
 
-	return w.count < p.config.RateCapPerHour
+	return w
 }
 
-// consume takes one promotion from the per-network hourly window. When the
-// cap is exhausted the caller skips - it never queues and never deletes.
-func (p *Promoter) consume(network string) {
-	p.rate[network].count++
+// headroom reports whether the tier's per-network hourly budget has room,
+// without consuming any.
+func (p *Promoter) headroom(network string, tier rateTier) bool {
+	w := p.window(network)
+
+	switch tier {
+	case tierUncapped:
+		return true
+	case tierRare:
+		return w.rareCount < p.config.RareCapPerHour
+	default:
+		return w.commonCount < p.config.RateCapPerHour
+	}
+}
+
+// consume takes one promotion from the tier's hourly budget. When a budget
+// is exhausted the caller skips - it never queues and never deletes.
+func (p *Promoter) consume(network string, tier rateTier) {
+	switch tier {
+	case tierUncapped:
+	case tierRare:
+		p.window(network).rareCount++
+	default:
+		p.window(network).commonCount++
+	}
 }
 
 // promote copies the candidate block, its pre-state (the post-state of its
@@ -636,7 +685,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 	}
 
 	id := captureID(cand.slot, cand.root)
-	bypassCap := slices.Contains(triggers, TriggerReorg)
+	tier := classifyTier(triggers)
 
 	// Provisional dedupe with the cached network GVR: on a rescan this
 	// skips the capture before any state-sized fetch happens.
@@ -653,9 +702,14 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 
 	// Cheap headroom probe before the state fetch; the budget is only
 	// consumed once the capture is known to be new.
-	if !bypassCap && !p.headroom(pass.network) {
-		p.metrics.ObserveSkip(pass.network, SkipReasonRateCapped)
-		p.log.WithFields(logrus.Fields{labelNetwork: pass.network, labelSlot: cand.slot, labelBlockRoot: cand.root}).Debug("Rate cap exhausted, skipping promotion")
+	if !p.headroom(pass.network, tier) {
+		reason := SkipReasonRateCappedCommon
+		if tier == tierRare {
+			reason = SkipReasonRateCappedRare
+		}
+
+		p.metrics.ObserveSkip(pass.network, reason)
+		p.log.WithFields(logrus.Fields{labelNetwork: pass.network, labelSlot: cand.slot, labelBlockRoot: cand.root, "tier": reason}).Debug("Rate cap exhausted, skipping promotion")
 
 		return nil
 	}
@@ -773,9 +827,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 	// The manifest is the commit point: budget is only consumed once the
 	// capture actually landed, so a corpus-store outage cannot burn the
 	// hourly window on failed writes.
-	if !bypassCap {
-		p.consume(pass.network)
-	}
+	p.consume(pass.network, tier)
 
 	p.metrics.ObserveCorpusBytes(pass.network, "manifest", len(data))
 	p.metrics.ObserveCapture(pass.network, branch)

--- a/pkg/server/service/promotion/promotion.go
+++ b/pkg/server/service/promotion/promotion.go
@@ -60,6 +60,12 @@ const (
 	// simply drains over the following ticks.
 	maxEpochsPerTick = 64
 
+	// stopTimeout bounds how long Stop waits for an in-flight tick. The
+	// context the server hands to Stop is the process context, which is not
+	// cancelled during shutdown, so the bound has to come from here: a tick
+	// blocked on a slow corpus store must not hold the process open.
+	stopTimeout = 30 * time.Second
+
 	// networkIdentityTTL is how long a resolved genesis validators root is
 	// trusted before it is re-resolved. Devnets are torn down and recreated
 	// under the same config name constantly, so the GVR is refreshed rather
@@ -89,8 +95,12 @@ type Promoter struct {
 	// rescanned; idempotency makes that free.
 	networks map[string]*networkState
 
-	done     chan struct{}
-	stopped  chan struct{}
+	done chan struct{}
+
+	// running counts the run loop, so Stop waits for a tick that is
+	// actually in flight and returns immediately for a loop that was never
+	// started.
+	running  sync.WaitGroup
 	stopOnce sync.Once
 }
 
@@ -163,7 +173,6 @@ func NewPromoter(ctx context.Context, log logrus.FieldLogger, conf *Config, db *
 		metrics:  GetMetricsInstance(namespace),
 		networks: make(map[string]*networkState),
 		done:     make(chan struct{}),
-		stopped:  make(chan struct{}),
 	}, nil
 }
 
@@ -193,6 +202,8 @@ func (p *Promoter) Start(ctx context.Context, _ *grpc.Server) error {
 		return errors.Wrap(err, "failed to connect to corpus store")
 	}
 
+	p.running.Add(1)
+
 	go p.run(ctx)
 
 	return nil
@@ -201,14 +212,33 @@ func (p *Promoter) Start(ctx context.Context, _ *grpc.Server) error {
 // Stop implements service.GRPCService. It waits for an in-flight tick to
 // finish: the service only ever adds objects, but a half-written capture is
 // worth avoiding when the shutdown is orderly.
+//
+// The wait must be able to give up. Stop also runs when Start never launched
+// the loop - the corpus store was unreachable, or an earlier service failed
+// first - and it is called with the process context, which shutdown does not
+// cancel. A wait that only a running loop can satisfy would hang the process
+// with the signal handler already spent, leaving SIGKILL as the only way out.
 func (p *Promoter) Stop(ctx context.Context) error {
 	p.log.Info("Stopping promotion service")
 
 	p.stopOnce.Do(func() { close(p.done) })
 
+	// Zero when the loop never started, so this returns immediately.
+	finished := make(chan struct{})
+
+	go func() {
+		p.running.Wait()
+		close(finished)
+	}()
+
+	timeout := time.NewTimer(stopTimeout)
+	defer timeout.Stop()
+
 	select {
-	case <-p.stopped:
+	case <-finished:
 	case <-ctx.Done():
+		p.log.Warn("Context cancelled while waiting for the promotion loop to finish")
+	case <-timeout.C:
 		p.log.Warn("Timed out waiting for the promotion loop to finish")
 	}
 
@@ -216,7 +246,7 @@ func (p *Promoter) Stop(ctx context.Context) error {
 }
 
 func (p *Promoter) run(ctx context.Context) {
-	defer close(p.stopped)
+	defer p.running.Done()
 
 	// Process immediately: everything still inside the retention window is
 	// fair game, oldest first, and re-processing is idempotent.

--- a/pkg/server/service/promotion/promotion.go
+++ b/pkg/server/service/promotion/promotion.go
@@ -1,0 +1,900 @@
+// Package promotion implements the tracoor promotion service: it watches the
+// short-retention capture buffer with hindsight and copies interesting
+// (pre-state, block) pairs - plus a manifest - into a separate, global,
+// append-only corpus store that outlives every devnet.
+//
+// The service never deletes anything, anywhere: copy-only toward the corpus,
+// read-only toward the buffer. It keeps no persistent state; promotion is
+// idempotent by construction (content-addressed states, (slot, block_root)
+// derived capture ids), so a restart simply rescans the still-retained
+// window.
+package promotion
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+
+	"github.com/ethpandaops/tracoor/pkg/compression"
+	"github.com/ethpandaops/tracoor/pkg/proto/tracoor"
+	"github.com/ethpandaops/tracoor/pkg/server/persistence"
+	"github.com/ethpandaops/tracoor/pkg/store"
+)
+
+const (
+	// ServiceType uniquely identifies the promotion service.
+	ServiceType = "tracoor.promotion"
+
+	namespace = "tracoor_server_promotion"
+
+	orderSlotAsc  = "slot ASC"
+	orderSlotDesc = "slot DESC"
+
+	// epochRowLimit bounds a single epoch listing; 32-ish slots times a
+	// handful of nodes sits far below it.
+	epochRowLimit = 10000
+)
+
+// Promoter is the promotion service. All mutable state is owned by the single
+// run goroutine; no locking is required beyond the stop guard.
+type Promoter struct {
+	log     logrus.FieldLogger
+	config  *Config
+	db      *persistence.Indexer
+	buffer  store.Store
+	corpus  store.Store
+	metrics *Metrics
+
+	// lastProcessedEpoch tracks per-network progress for this process
+	// lifetime only - deliberately not persisted. On restart the whole
+	// retained window is rescanned; idempotency makes that free.
+	lastProcessedEpoch map[string]uint64
+
+	// networkGVR caches the first genesis validators root observed per
+	// network name. Pairings verified by root carry their own GVR; the
+	// cache only anchors fallback pairings and block-only promotions.
+	networkGVR map[string]string
+
+	rate map[string]*rateWindow
+
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+type rateWindow struct {
+	start time.Time
+	count uint64
+}
+
+// NewPromoter creates the promotion service. The corpus store is built from
+// the service's own store config and must not be the buffer store.
+func NewPromoter(ctx context.Context, log logrus.FieldLogger, conf *Config, db *persistence.Indexer, buffer store.Store) (*Promoter, error) {
+	if err := conf.Validate(); err != nil {
+		return nil, err
+	}
+
+	corpus, err := store.NewStore(namespace, log, conf.Store.Type, conf.Store.Config, store.DefaultOptions())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create corpus store")
+	}
+
+	return &Promoter{
+		log:                log.WithField("server/module", ServiceType),
+		config:             conf,
+		db:                 db,
+		buffer:             buffer,
+		corpus:             corpus,
+		metrics:            GetMetricsInstance(namespace, true),
+		lastProcessedEpoch: make(map[string]uint64),
+		networkGVR:         make(map[string]string),
+		rate:               make(map[string]*rateWindow),
+		done:               make(chan struct{}),
+	}, nil
+}
+
+// Start implements service.GRPCService. The promotion service exposes no RPCs
+// of its own; it only registers its background loop.
+func (p *Promoter) Start(ctx context.Context, _ *grpc.Server) error {
+	p.log.WithFields(logrus.Fields{
+		"lag_epochs":        p.config.LagEpochs,
+		"check_interval":    p.config.CheckInterval.Duration.String(),
+		"rate_cap_per_hour": p.config.RateCapPerHour,
+	}).Info("Starting promotion service")
+
+	if err := p.corpus.Healthy(ctx); err != nil {
+		return errors.Wrap(err, "failed to connect to corpus store")
+	}
+
+	go p.run(ctx)
+
+	return nil
+}
+
+// Stop implements service.GRPCService.
+func (p *Promoter) Stop(_ context.Context) error {
+	p.log.Info("Stopping promotion service")
+
+	p.stopOnce.Do(func() { close(p.done) })
+
+	return nil
+}
+
+func (p *Promoter) run(ctx context.Context) {
+	// Process immediately: everything still inside the retention window is
+	// fair game, oldest first, and re-processing is idempotent.
+	p.tick(ctx)
+
+	ticker := time.NewTicker(p.config.CheckInterval.Duration)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.done:
+			return
+		case <-ticker.C:
+			p.tick(ctx)
+		}
+	}
+}
+
+func (p *Promoter) tick(ctx context.Context) {
+	values, err := p.db.DistinctBeaconBlockValues(ctx, []string{"network"})
+	if err != nil {
+		p.log.WithError(err).Error("Failed to list networks")
+
+		return
+	}
+
+	for _, network := range values.Network {
+		if network == "" {
+			continue
+		}
+
+		if err := p.processNetwork(ctx, network); err != nil {
+			p.metrics.ObserveError(network)
+			p.log.WithError(err).WithField("network", network).Error("Failed to process network")
+		}
+	}
+}
+
+func (p *Promoter) processNetwork(ctx context.Context, network string) error {
+	head, err := p.edgeBlock(ctx, network, orderSlotDesc)
+	if err != nil || head == nil {
+		return err
+	}
+
+	headEpoch, headSlot := uint64(head.Epoch), uint64(head.Slot) //nolint:gosec // slots/epochs are non-negative
+	if headEpoch < p.config.LagEpochs {
+		return nil
+	}
+
+	target := headEpoch - p.config.LagEpochs
+
+	from, seen := p.lastProcessedEpoch[network]
+	if seen {
+		from++
+	} else {
+		oldest, oerr := p.edgeBlock(ctx, network, orderSlotAsc)
+		if oerr != nil || oldest == nil {
+			return oerr
+		}
+
+		from = uint64(oldest.Epoch) //nolint:gosec // slots/epochs are non-negative
+	}
+
+	for epoch := from; epoch <= target; epoch++ {
+		if err := p.processEpoch(ctx, network, epoch, headSlot); err != nil {
+			// Do not advance past a failing epoch; retry next tick. The
+			// retention reaper bounds how long that can go on, and the
+			// error metric makes the loss visible, never silent.
+			return errors.Wrapf(err, "failed to process epoch %d", epoch)
+		}
+
+		p.lastProcessedEpoch[network] = epoch
+		p.metrics.ObserveLastProcessedEpoch(network, epoch)
+	}
+
+	return nil
+}
+
+func (p *Promoter) edgeBlock(ctx context.Context, network, order string) (*persistence.BeaconBlock, error) {
+	rows, err := p.db.ListBeaconBlock(ctx, &persistence.BeaconBlockFilter{Network: &network}, &persistence.PaginationCursor{Limit: 1, OrderBy: order})
+	if err != nil || len(rows) == 0 {
+		return nil, err
+	}
+
+	return rows[0], nil
+}
+
+// candidate is one distinct block root at one slot, with the raw bytes any
+// node served for it.
+type candidate struct {
+	slot    uint64
+	root    string // normalised 0x hex, from the index
+	node    string
+	raw     []byte // decompressed SSZ, exactly as the node served it
+	peek    *blockPeek
+	decoded *spec.VersionedSignedBeaconBlock // nil when undecodable
+	latest  time.Time                        // newest FetchedAt across rows
+}
+
+// epochPass is the working set for one (network, epoch).
+type epochPass struct {
+	network  string
+	epoch    uint64
+	headSlot uint64
+
+	bySlot map[uint64][]*candidate
+	byRoot map[string]*candidate
+	slots  []uint64
+
+	// children holds every parent_root referenced by a candidate in this
+	// pass: deterministic evidence for canonical-branch resolution.
+	children map[string]bool
+}
+
+func (p *Promoter) processEpoch(ctx context.Context, network string, epoch, headSlot uint64) error {
+	rows, err := p.db.ListBeaconBlock(ctx, &persistence.BeaconBlockFilter{Network: &network, Epoch: &epoch}, &persistence.PaginationCursor{Limit: epochRowLimit, OrderBy: orderSlotAsc})
+	if err != nil {
+		return err
+	}
+
+	if len(rows) == 0 {
+		return nil
+	}
+
+	pass := &epochPass{
+		network:  network,
+		epoch:    epoch,
+		headSlot: headSlot,
+		bySlot:   make(map[uint64][]*candidate),
+		byRoot:   make(map[string]*candidate),
+		children: make(map[string]bool),
+	}
+
+	p.buildCandidates(ctx, pass, rows)
+
+	sort.Slice(pass.slots, func(i, j int) bool { return pass.slots[i] < pass.slots[j] })
+
+	baselineSlot, haveBaseline := p.baselineSlot(pass)
+
+	for _, slot := range pass.slots {
+		cands := pass.bySlot[slot]
+		isReorg := len(cands) > 1
+		branches := p.resolveBranches(ctx, pass, cands)
+
+		for _, cand := range cands {
+			parent := p.resolveParent(ctx, pass, normHex(cand.peek.ParentRoot.String()))
+
+			triggers := p.evaluateCandidate(cand, parent, isReorg, haveBaseline && slot == baselineSlot)
+			if len(triggers) == 0 {
+				continue
+			}
+
+			if err := p.promote(ctx, pass, cand, parent, triggers, branches[cand.root]); err != nil {
+				p.metrics.ObserveError(network)
+				p.log.WithError(err).WithFields(logrus.Fields{"network": network, "slot": slot, "block_root": cand.root}).Error("Failed to promote candidate")
+			}
+		}
+	}
+
+	return nil
+}
+
+// buildCandidates fetches every distinct root's bytes once and byte-peeks the
+// fork-stable fields. Rows whose object is gone or malformed degrade to
+// skipped candidates with a metric, never to a failed epoch.
+func (p *Promoter) buildCandidates(ctx context.Context, pass *epochPass, rows []*persistence.BeaconBlock) {
+	byRoot := make(map[string][]*persistence.BeaconBlock)
+
+	for _, row := range rows {
+		if row.Slot < 0 || row.BlockRoot == "" {
+			continue
+		}
+
+		byRoot[normHex(row.BlockRoot)] = append(byRoot[normHex(row.BlockRoot)], row)
+	}
+
+	for root, group := range byRoot {
+		cand := &candidate{
+			slot: uint64(group[0].Slot), //nolint:gosec // guarded non-negative above
+			root: root,
+		}
+
+		for _, row := range group {
+			if row.FetchedAt.After(cand.latest) {
+				cand.latest = row.FetchedAt
+			}
+		}
+
+		if !p.loadCandidate(ctx, pass.network, cand, group) {
+			continue
+		}
+
+		pass.byRoot[root] = cand
+		pass.children[normHex(cand.peek.ParentRoot.String())] = true
+
+		if _, ok := pass.bySlot[cand.slot]; !ok {
+			pass.slots = append(pass.slots, cand.slot)
+		}
+
+		pass.bySlot[cand.slot] = append(pass.bySlot[cand.slot], cand)
+	}
+
+	// Deterministic order for same-slot branches.
+	for _, cands := range pass.bySlot {
+		sort.Slice(cands, func(i, j int) bool { return cands[i].root < cands[j].root })
+	}
+}
+
+// loadCandidate fetches, decompresses and peeks a block from any node's copy.
+func (p *Promoter) loadCandidate(ctx context.Context, network string, cand *candidate, rows []*persistence.BeaconBlock) bool {
+	for _, row := range rows {
+		data, err := p.buffer.GetBeaconBlock(ctx, row.Location)
+		if err != nil || data == nil {
+			continue
+		}
+
+		raw, err := decompress(*data, row.ContentEncoding)
+		if err != nil {
+			p.log.WithError(err).WithField("location", row.Location).Warn("Failed to decompress block")
+
+			continue
+		}
+
+		peek, err := peekBlock(raw)
+		if err != nil || peek.Slot != cand.slot {
+			// Truncated or misfiled: promote nothing under a label the
+			// payload contradicts.
+			p.metrics.ObserveSkip(network, SkipReasonMalformed)
+			p.log.WithError(err).WithFields(logrus.Fields{"location": row.Location, "slot": cand.slot}).Warn("Block bytes fail sanity rules")
+
+			continue
+		}
+
+		cand.raw = raw
+		cand.peek = peek
+		cand.node = row.Node
+		cand.decoded, _ = decodeBlock(raw)
+
+		return true
+	}
+
+	p.metrics.ObserveSkip(network, SkipReasonMissingObject)
+
+	return false
+}
+
+// baselineSlot returns the first qualifying slot of a baseline epoch. It is a
+// pure function of the epoch number so re-processing selects the same slots.
+// Requires pass.slots to be sorted.
+func (p *Promoter) baselineSlot(pass *epochPass) (uint64, bool) {
+	if !triggerEnabled(p.config.Triggers.Baseline) || p.config.BaselineEveryNEpochs == 0 {
+		return 0, false
+	}
+
+	if pass.epoch%p.config.BaselineEveryNEpochs != 0 || len(pass.slots) == 0 {
+		return 0, false
+	}
+
+	return pass.slots[0], true
+}
+
+// parentInfo is everything known about a candidate's parent, resolved by
+// parent_root - never by slot arithmetic: skipped slots make them differ.
+type parentInfo struct {
+	known   bool
+	slot    uint64
+	peek    *blockPeek
+	version spec.DataVersion
+}
+
+func (p *Promoter) resolveParent(ctx context.Context, pass *epochPass, parentRoot string) parentInfo {
+	if cand, ok := pass.byRoot[parentRoot]; ok {
+		info := parentInfo{known: true, slot: cand.slot, peek: cand.peek}
+		if cand.decoded != nil {
+			info.version = cand.decoded.Version
+		}
+
+		return info
+	}
+
+	rows, err := p.db.ListBeaconBlock(ctx, &persistence.BeaconBlockFilter{Network: &pass.network, BlockRoot: &parentRoot}, &persistence.PaginationCursor{Limit: 10, OrderBy: orderSlotAsc})
+	if err != nil || len(rows) == 0 || rows[0].Slot < 0 {
+		return parentInfo{}
+	}
+
+	info := parentInfo{known: true, slot: uint64(rows[0].Slot)} //nolint:gosec // guarded non-negative above
+
+	cand := &candidate{slot: info.slot, root: parentRoot}
+	if p.loadCandidate(ctx, pass.network, cand, rows) {
+		info.peek = cand.peek
+		if cand.decoded != nil {
+			info.version = cand.decoded.Version
+		}
+	}
+
+	return info
+}
+
+func (p *Promoter) evaluateCandidate(cand *candidate, parent parentInfo, isReorg, isBaseline bool) []string {
+	var triggers []string
+
+	if isReorg && triggerEnabled(p.config.Triggers.Reorg) {
+		triggers = append(triggers, TriggerReorg)
+	}
+
+	if cand.decoded == nil {
+		// A fork too new to decode is a fork whose states are all
+		// interesting.
+		if triggerEnabled(p.config.Triggers.UndecodableFork) {
+			triggers = append(triggers, TriggerUndecodableFork)
+		}
+	} else {
+		triggers = append(triggers, p.decodedTriggers(cand.decoded)...)
+	}
+
+	if triggerEnabled(p.config.Triggers.Gap) && parent.known && cand.slot > parent.slot {
+		if cand.slot-parent.slot-1 >= p.config.GapTrigger {
+			triggers = append(triggers, TriggerGap)
+		}
+	}
+
+	if triggerEnabled(p.config.Triggers.ForkBoundary) && cand.decoded != nil &&
+		parent.version != spec.DataVersionUnknown && parent.version != cand.decoded.Version {
+		triggers = append(triggers, TriggerForkBoundary)
+	}
+
+	if isBaseline {
+		triggers = append(triggers, TriggerBaseline)
+	}
+
+	return triggers
+}
+
+// resolveBranches labels each root at a slot canonical or orphaned. The
+// preferred evidence is deterministic: the root referenced as parent_root by
+// a later block won. Recency of capture is the fallback (tracoor re-captures
+// the winning branch after a reorg event).
+func (p *Promoter) resolveBranches(ctx context.Context, pass *epochPass, cands []*candidate) map[string]string {
+	out := make(map[string]string, len(cands))
+	if len(cands) == 1 {
+		out[cands[0].root] = BranchCanonical
+
+		return out
+	}
+
+	referenced := make([]*candidate, 0, len(cands))
+
+	for _, cand := range cands {
+		if pass.children[cand.root] {
+			referenced = append(referenced, cand)
+		}
+	}
+
+	if len(referenced) == 0 {
+		// The reorged slot has no in-pass child (epoch tail); look ahead
+		// one epoch for parent references before falling back to recency.
+		lookahead := p.lookaheadChildren(ctx, pass)
+		for _, cand := range cands {
+			if lookahead[cand.root] {
+				referenced = append(referenced, cand)
+			}
+		}
+	}
+
+	if len(referenced) == 0 {
+		referenced = cands
+	}
+
+	canonical := referenced[0]
+	for _, cand := range referenced[1:] {
+		if cand.latest.After(canonical.latest) {
+			canonical = cand
+		}
+	}
+
+	for _, cand := range cands {
+		if cand == canonical {
+			out[cand.root] = BranchCanonical
+		} else {
+			out[cand.root] = BranchOrphaned
+		}
+	}
+
+	return out
+}
+
+// lookaheadChildren byte-peeks the earliest blocks of the next epoch and
+// returns the set of parent roots they reference.
+func (p *Promoter) lookaheadChildren(ctx context.Context, pass *epochPass) map[string]bool {
+	out := make(map[string]bool)
+	next := pass.epoch + 1
+
+	rows, err := p.db.ListBeaconBlock(ctx, &persistence.BeaconBlockFilter{Network: &pass.network, Epoch: &next}, &persistence.PaginationCursor{Limit: 20, OrderBy: orderSlotAsc})
+	if err != nil {
+		return out
+	}
+
+	seen := make(map[string]bool)
+
+	for _, row := range rows {
+		root := normHex(row.BlockRoot)
+		if seen[root] {
+			continue
+		}
+
+		seen[root] = true
+
+		data, err := p.buffer.GetBeaconBlock(ctx, row.Location)
+		if err != nil || data == nil {
+			continue
+		}
+
+		raw, err := decompress(*data, row.ContentEncoding)
+		if err != nil {
+			continue
+		}
+
+		if peek, perr := peekBlock(raw); perr == nil {
+			out[normHex(peek.ParentRoot.String())] = true
+		}
+	}
+
+	return out
+}
+
+// headroom reports whether the per-network hourly window has budget left,
+// without consuming any.
+func (p *Promoter) headroom(network string) bool {
+	now := time.Now()
+
+	w := p.rate[network]
+	if w == nil || now.Sub(w.start) >= time.Hour {
+		w = &rateWindow{start: now}
+		p.rate[network] = w
+	}
+
+	return w.count < p.config.RateCapPerHour
+}
+
+// consume takes one promotion from the per-network hourly window. When the
+// cap is exhausted the caller skips - it never queues and never deletes.
+func (p *Promoter) consume(network string) {
+	p.rate[network].count++
+}
+
+// promote copies the candidate block, its pre-state (the post-state of its
+// PARENT, resolved by parent_root) and a manifest into the corpus.
+//
+// Ordering matters: already-promoted captures are detected before the rate
+// cap is consulted, so a restart-rescan of the retained window is free and
+// never burns the hourly budget on captures the corpus already has.
+func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate, parent parentInfo, triggers []string, branch string) error {
+	forkName := "unknown"
+	if cand.decoded != nil {
+		forkName = cand.decoded.Version.String()
+	}
+
+	id := captureID(cand.slot, cand.root)
+	bypassCap := slices.Contains(triggers, TriggerReorg)
+
+	// Provisional dedupe with the cached network GVR: on a rescan this
+	// skips the capture before any state-sized fetch happens.
+	provisionalKey := ""
+
+	if gvr := p.resolveNetworkGVR(ctx, pass.network); gvr != "" {
+		provisionalKey = capturePath(networkID(pass.network, gvr), forkName, id, captureManifestName)
+		if exists, err := p.corpus.Exists(ctx, provisionalKey); err == nil && exists {
+			p.metrics.ObserveSkip(pass.network, SkipReasonAlreadyPromoted)
+
+			return nil
+		}
+	}
+
+	// Cheap headroom probe before the state fetch; the budget is only
+	// consumed once the capture is known to be new.
+	if !bypassCap && !p.headroom(pass.network) {
+		p.metrics.ObserveSkip(pass.network, SkipReasonRateCapped)
+		p.log.WithFields(logrus.Fields{"network": pass.network, "slot": cand.slot, "block_root": cand.root}).Debug("Rate cap exhausted, skipping promotion")
+
+		return nil
+	}
+
+	// expected_state_root is the PARENT block's own state_root field - not
+	// the candidate's, which is the child's POST-state root, off by exactly
+	// one block. Omitted rather than substituted when the parent block is
+	// missing: a missing claim is honest, a wrong one poisons.
+	expectedStateRoot := ""
+	if parent.peek != nil {
+		expectedStateRoot = normHex(parent.peek.StateRoot.String())
+	}
+
+	stateRaw, prestate := p.resolvePrestate(ctx, pass.network, parent, expectedStateRoot)
+
+	gvr := ""
+
+	if stateRaw != nil {
+		peek, err := peekState(stateRaw)
+		if err != nil {
+			return err
+		}
+
+		gvr = normHex(peek.GenesisValidatorsRoot.String())
+	} else {
+		// Block-only promotion: the network GVR must come from elsewhere
+		// in the buffer. Without one the capture cannot be filed under an
+		// unambiguous network id, and a wrong prefix mixes incompatible
+		// chains - skip, visibly.
+		gvr = p.resolveNetworkGVR(ctx, pass.network)
+		if gvr == "" {
+			p.metrics.ObserveSkip(pass.network, SkipReasonGVRAmbiguous)
+			p.log.WithFields(logrus.Fields{"network": pass.network, "slot": cand.slot}).Warn("No genesis validators root resolvable; refusing to label capture")
+
+			return nil
+		}
+	}
+
+	if p.networkGVR[pass.network] == "" {
+		p.networkGVR[pass.network] = gvr
+	}
+
+	network := networkID(pass.network, gvr)
+
+	// The pair's own GVR is authoritative for the capture key; re-check
+	// existence when it differs from the provisional guess.
+	manifestKey := capturePath(network, forkName, id, captureManifestName)
+	if manifestKey != provisionalKey {
+		if exists, err := p.corpus.Exists(ctx, manifestKey); err == nil && exists {
+			p.metrics.ObserveSkip(pass.network, SkipReasonAlreadyPromoted)
+
+			return nil
+		}
+	}
+
+	if !bypassCap {
+		p.consume(pass.network)
+	}
+
+	if stateRaw != nil {
+		sha := sha256Hex(stateRaw)
+		if err := p.writeState(ctx, pass.network, stateRaw, sha); err != nil {
+			return errors.Wrap(err, "failed to write pre-state")
+		}
+
+		prestate.SHA256 = sha
+		prestate.Size = len(stateRaw)
+		prestate.ExpectedStateRoot = expectedStateRoot
+	}
+
+	if _, err := p.corpus.SaveRaw(ctx, &store.SaveParams{Data: &cand.raw, Location: capturePath(network, forkName, id, captureBlockName)}); err != nil {
+		return errors.Wrap(err, "failed to write block")
+	}
+
+	p.metrics.ObserveCorpusBytes(pass.network, "block", len(cand.raw))
+
+	manifest := &Manifest{
+		Schema:     manifestSchema,
+		Tool:       tracoor.Full(),
+		PromotedAt: time.Now().UTC(),
+		Network: ManifestNetwork{
+			Name:                  network,
+			ConfigName:            pass.network,
+			GenesisValidatorsRoot: gvr,
+			SlotsPerEpoch:         p.config.SlotsPerEpoch,
+			SecondsPerSlot:        uint64(p.config.SecondsPerSlot.Seconds()),
+		},
+		Fork: ManifestFork{Name: forkName},
+		Block: ManifestBlock{
+			Slot:       cand.slot,
+			Root:       cand.root,
+			ParentRoot: normHex(cand.peek.ParentRoot.String()),
+			StateRoot:  normHex(cand.peek.StateRoot.String()),
+			SHA256:     sha256Hex(cand.raw),
+			Size:       len(cand.raw),
+		},
+		Prestate: prestate,
+		Promotion: ManifestPromotion{
+			Triggers: triggers,
+			Decoded:  cand.decoded != nil,
+			// An undecodable fork leaves the pairing claim unproven even
+			// when the byte-peeked chain checks out.
+			PairVerified: cand.decoded != nil && prestate != nil && prestate.ExpectedStateRoot != "",
+			Branch:       branch,
+			LagEpochs:    p.config.LagEpochs,
+		},
+		Context: ManifestContext{HeadSlotAtPromotion: pass.headSlot},
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal manifest")
+	}
+
+	if _, err := p.corpus.SaveRaw(ctx, &store.SaveParams{Data: &data, Location: manifestKey}); err != nil {
+		return errors.Wrap(err, "failed to write manifest")
+	}
+
+	p.metrics.ObserveCorpusBytes(pass.network, "manifest", len(data))
+	p.metrics.ObserveCapture(pass.network, branch)
+
+	if prestate == nil {
+		p.metrics.ObserveUnpaired(pass.network)
+	}
+
+	for _, trigger := range triggers {
+		p.metrics.ObserveTrigger(pass.network, trigger)
+	}
+
+	p.log.WithFields(logrus.Fields{
+		"network":       network,
+		"slot":          cand.slot,
+		"block_root":    cand.root,
+		"triggers":      triggers,
+		"branch":        branch,
+		"pair_verified": manifest.Promotion.PairVerified,
+	}).Info("Promoted capture to corpus")
+
+	return nil
+}
+
+// resolvePrestate locates and verifies the parent's post-state in the buffer.
+// When the parent block's own state_root is known, only the branch-exact row
+// qualifies; without it, a slot-level fallback is accepted but the pairing
+// stays unverified and must at least be GVR-consistent with the network.
+func (p *Promoter) resolvePrestate(ctx context.Context, network string, parent parentInfo, expectedStateRoot string) ([]byte, *ManifestPrestate) {
+	if !parent.known {
+		return nil, nil
+	}
+
+	rows, err := p.db.ListBeaconState(ctx, &persistence.BeaconStateFilter{Network: &network, Slot: &parent.slot}, &persistence.PaginationCursor{Limit: 100, OrderBy: "fetched_at ASC"})
+	if err != nil {
+		return nil, nil
+	}
+
+	for _, row := range rows {
+		if expectedStateRoot != "" && normHex(row.StateRoot) != expectedStateRoot {
+			continue
+		}
+
+		data, gerr := p.buffer.GetBeaconState(ctx, row.Location)
+		if gerr != nil || data == nil {
+			continue
+		}
+
+		raw, derr := decompress(*data, row.ContentEncoding)
+		if derr != nil {
+			continue
+		}
+
+		peek, perr := peekState(raw)
+		if perr != nil || peek.Slot != parent.slot {
+			// Misfiled or truncated: never pair under a claim the bytes
+			// contradict.
+			p.metrics.ObserveSkip(network, SkipReasonMalformed)
+
+			continue
+		}
+
+		if expectedStateRoot == "" {
+			// Fallback pairing cannot be branch-verified; refuse states
+			// whose GVR contradicts the network to avoid mixing recreated
+			// chains under one prefix.
+			gvr := normHex(peek.GenesisValidatorsRoot.String())
+			if known := p.networkGVR[network]; known != "" && known != gvr {
+				p.metrics.ObserveSkip(network, SkipReasonGVRAmbiguous)
+
+				continue
+			}
+		}
+
+		return raw, &ManifestPrestate{
+			Slot:       parent.slot,
+			SourceNode: row.Node,
+		}
+	}
+
+	return nil, nil
+}
+
+// writeState writes a content-addressed, uncompressed state object. The
+// existence probe is an optimisation, not a correctness requirement: two
+// racing deployments write identical bytes to identical keys.
+func (p *Promoter) writeState(ctx context.Context, network string, raw []byte, sha string) error {
+	location := statePath(sha)
+
+	exists, err := p.corpus.Exists(ctx, location)
+	if err == nil && exists {
+		return nil
+	}
+
+	if _, err := p.corpus.SaveRaw(ctx, &store.SaveParams{Data: &raw, Location: location}); err != nil {
+		return err
+	}
+
+	p.metrics.ObserveCorpusBytes(network, "state", len(raw))
+
+	return nil
+}
+
+// resolveNetworkGVR resolves a network's genesis validators root from any
+// retained state, cached per network name for the process lifetime.
+func (p *Promoter) resolveNetworkGVR(ctx context.Context, network string) string {
+	if gvr := p.networkGVR[network]; gvr != "" {
+		return gvr
+	}
+
+	rows, err := p.db.ListBeaconState(ctx, &persistence.BeaconStateFilter{Network: &network}, &persistence.PaginationCursor{Limit: 5, OrderBy: "fetched_at DESC"})
+	if err != nil {
+		return ""
+	}
+
+	for _, row := range rows {
+		data, gerr := p.buffer.GetBeaconState(ctx, row.Location)
+		if gerr != nil || data == nil {
+			continue
+		}
+
+		raw, derr := decompress(*data, row.ContentEncoding)
+		if derr != nil {
+			continue
+		}
+
+		if peek, perr := peekState(raw); perr == nil {
+			gvr := normHex(peek.GenesisValidatorsRoot.String())
+			p.networkGVR[network] = gvr
+
+			return gvr
+		}
+	}
+
+	return ""
+}
+
+// decompress undoes the buffer's content encoding. Corpus objects are always
+// written uncompressed: the sha256 of the raw SSZ is the identity.
+func decompress(data []byte, contentEncoding string) ([]byte, error) {
+	switch contentEncoding {
+	case compression.Gzip.ContentEncoding:
+		reader, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+
+		return io.ReadAll(reader)
+	case compression.None.ContentEncoding, "":
+		return data, nil
+	default:
+		return nil, fmt.Errorf("unsupported content encoding: %q", contentEncoding)
+	}
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+
+	return hex.EncodeToString(sum[:])
+}
+
+// normHex lower-cases a hex string and guarantees a 0x prefix so roots from
+// the index and roots from byte-peeks compare equal.
+func normHex(s string) string {
+	return "0x" + strings.ToLower(strings.TrimPrefix(s, "0x"))
+}

--- a/pkg/server/service/promotion/promotion.go
+++ b/pkg/server/service/promotion/promotion.go
@@ -46,17 +46,32 @@ const (
 	orderSlotDesc = "slot DESC"
 
 	// epochRowLimit bounds a single epoch listing; 32-ish slots times a
-	// handful of nodes sits far below it.
+	// handful of nodes sits far below it. Hitting it is reported, never
+	// silent: a truncated listing is indistinguishable from a short epoch.
 	epochRowLimit = 10000
 
 	// maxEpochAttempts bounds how often a failing epoch is retried before
 	// the service abandons it and moves on.
 	maxEpochAttempts = 10
 
+	// maxEpochsPerTick bounds the work of a single tick. A cold start on a
+	// long retention window, or a mis-indexed row claiming an absurd epoch,
+	// must not turn one tick into an unbounded run of queries; the backlog
+	// simply drains over the following ticks.
+	maxEpochsPerTick = 64
+
+	// networkIdentityTTL is how long a resolved genesis validators root is
+	// trusted before it is re-resolved. Devnets are torn down and recreated
+	// under the same config name constantly, so the GVR is refreshed rather
+	// than pinned for the process lifetime - at the cost of one state fetch
+	// per network per TTL.
+	networkIdentityTTL = 15 * time.Minute
+
 	// Shared log-field and metric-label keys.
 	labelNetwork   = "network"
 	labelSlot      = "slot"
 	labelBlockRoot = "block_root"
+	labelEpoch     = "epoch"
 )
 
 // Promoter is the promotion service. All mutable state is owned by the single
@@ -69,31 +84,57 @@ type Promoter struct {
 	corpus  store.Store
 	metrics *Metrics
 
-	// lastProcessedEpoch tracks per-network progress for this process
-	// lifetime only - deliberately not persisted. On restart the whole
-	// retained window is rescanned; idempotency makes that free.
-	lastProcessedEpoch map[string]uint64
-
-	// networkGVR caches the first genesis validators root observed per
-	// network name. Pairings verified by root carry their own GVR; the
-	// cache only anchors fallback pairings and block-only promotions.
-	networkGVR map[string]string
-
-	rate map[string]*rateWindow
-
-	// retries bounds how often a failing epoch is retried before the
-	// service advances past it: only the first failing epoch per network
-	// can block, so a single entry per network suffices.
-	retries map[string]*epochRetry
+	// networks holds per-network progress for this process lifetime only -
+	// deliberately not persisted. On restart the whole retained window is
+	// rescanned; idempotency makes that free.
+	networks map[string]*networkState
 
 	done     chan struct{}
+	stopped  chan struct{}
 	stopOnce sync.Once
+}
+
+// networkState is everything the service remembers about one network name
+// between ticks. Kurtosis devnets are recreated under the same name
+// constantly, so this state is explicitly resettable: see reset.
+type networkState struct {
+	// lastProcessedEpoch is the cursor; seen distinguishes "epoch 0 done"
+	// from "nothing done yet".
+	lastProcessedEpoch uint64
+	seen               bool
+
+	// gvr is the genesis validators root the network is currently filed
+	// under, and when it was resolved. Pairings verified by root carry
+	// their own GVR; this only anchors fallback pairings and block-only
+	// promotions.
+	gvr         string
+	gvrResolved time.Time
+
+	rate rateWindow
+
+	// retry bounds how often a failing epoch is retried before the service
+	// advances past it: only the first failing epoch can block, so a single
+	// entry per network suffices.
+	retry *epochRetry
+}
+
+// reset drops everything derived from a chain that no longer exists, so the
+// next pass rescans the retained window from its oldest epoch. The rate
+// window deliberately survives: a reset must not hand out a fresh hourly
+// budget, or repeated resets would become a way around the flood guard.
+func (s *networkState) reset() {
+	s.lastProcessedEpoch = 0
+	s.seen = false
+	s.gvr = ""
+	s.gvrResolved = time.Time{}
+	s.retry = nil
 }
 
 type rateWindow struct {
 	start       time.Time
 	commonCount uint64
 	rareCount   uint64
+	reorgCount  uint64
 }
 
 type epochRetry struct {
@@ -114,27 +155,38 @@ func NewPromoter(ctx context.Context, log logrus.FieldLogger, conf *Config, db *
 	}
 
 	return &Promoter{
-		log:                log.WithField("server/module", ServiceType),
-		config:             conf,
-		db:                 db,
-		buffer:             buffer,
-		corpus:             corpus,
-		metrics:            GetMetricsInstance(namespace, true),
-		lastProcessedEpoch: make(map[string]uint64),
-		networkGVR:         make(map[string]string),
-		rate:               make(map[string]*rateWindow),
-		retries:            make(map[string]*epochRetry),
-		done:               make(chan struct{}),
+		log:      log.WithField("server/module", ServiceType),
+		config:   conf,
+		db:       db,
+		buffer:   buffer,
+		corpus:   corpus,
+		metrics:  GetMetricsInstance(namespace),
+		networks: make(map[string]*networkState),
+		done:     make(chan struct{}),
+		stopped:  make(chan struct{}),
 	}, nil
+}
+
+// network returns the mutable state of a network, creating it on first sight.
+func (p *Promoter) network(name string) *networkState {
+	state, ok := p.networks[name]
+	if !ok {
+		state = &networkState{}
+		p.networks[name] = state
+	}
+
+	return state
 }
 
 // Start implements service.GRPCService. The promotion service exposes no RPCs
 // of its own; it only registers its background loop.
 func (p *Promoter) Start(ctx context.Context, _ *grpc.Server) error {
 	p.log.WithFields(logrus.Fields{
-		"lag_epochs":        p.config.LagEpochs,
-		"check_interval":    p.config.CheckInterval.Duration.String(),
-		"rate_cap_per_hour": p.config.RateCapPerHour,
+		"lag_epochs":         p.config.LagEpochs,
+		"check_interval":     p.config.CheckInterval.Duration.String(),
+		"rate_cap_per_hour":  p.config.RateCapPerHour,
+		"rare_cap_per_hour":  p.config.RareCapPerHour,
+		"reorg_cap_per_hour": p.config.ReorgCapPerHour,
 	}).Info("Starting promotion service")
 
 	if err := p.corpus.Healthy(ctx); err != nil {
@@ -146,16 +198,26 @@ func (p *Promoter) Start(ctx context.Context, _ *grpc.Server) error {
 	return nil
 }
 
-// Stop implements service.GRPCService.
-func (p *Promoter) Stop(_ context.Context) error {
+// Stop implements service.GRPCService. It waits for an in-flight tick to
+// finish: the service only ever adds objects, but a half-written capture is
+// worth avoiding when the shutdown is orderly.
+func (p *Promoter) Stop(ctx context.Context) error {
 	p.log.Info("Stopping promotion service")
 
 	p.stopOnce.Do(func() { close(p.done) })
+
+	select {
+	case <-p.stopped:
+	case <-ctx.Done():
+		p.log.Warn("Timed out waiting for the promotion loop to finish")
+	}
 
 	return nil
 }
 
 func (p *Promoter) run(ctx context.Context) {
+	defer close(p.stopped)
+
 	// Process immediately: everything still inside the retention window is
 	// fair game, oldest first, and re-processing is idempotent.
 	p.tick(ctx)
@@ -201,35 +263,92 @@ func (p *Promoter) processNetwork(ctx context.Context, network string) error {
 		return err
 	}
 
-	headEpoch, headSlot := uint64(head.Epoch), uint64(head.Slot) //nolint:gosec // slots/epochs are non-negative
+	state := p.network(network)
+
+	headSlot := uint64(head.Slot) //nolint:gosec // slots are non-negative
+	headEpoch := p.headEpoch(network, head)
+
 	if headEpoch < p.config.LagEpochs {
 		return nil
 	}
 
 	target := headEpoch - p.config.LagEpochs
 
-	from, seen := p.lastProcessedEpoch[network]
-	if seen {
-		from++
-	} else {
+	// A cursor ahead of the target means the chain under this name lost
+	// height: a devnet recreated under the same name (slots restart at 0),
+	// or a mis-indexed row that has since been reaped. Without this the
+	// cursor - which only ever moves forward - would sit above every real
+	// epoch and the service would silently promote nothing until restart.
+	if state.seen && target < state.lastProcessedEpoch {
+		p.log.WithFields(logrus.Fields{
+			labelNetwork:  network,
+			"cursor":      state.lastProcessedEpoch,
+			"head_epoch":  headEpoch,
+			"head_slot":   headSlot,
+			"target":      target,
+			"reset_cause": "height_regression",
+		}).Warn("Network lost height; resetting promotion cursor and network identity")
+
+		state.reset()
+		p.metrics.ObserveNetworkReset(network, ResetReasonHeightRegression)
+	}
+
+	// Resolve the network identity before promoting anything under it. A
+	// changed GVR is the same event seen from the other side, and it can
+	// arrive while the buffer still holds both chains.
+	if p.refreshIdentity(ctx, network, state) && state.seen {
+		// The backlog between the cursor and the target belongs to a chain
+		// this name no longer denotes. Skip it rather than relabel its
+		// captures under the new identity: block-only promotions take
+		// their network id from the cache, so a rescan here would file the
+		// old chain's blocks under the new chain's name. Once the reaper
+		// finishes clearing the old chain the height regression above
+		// fires and rescans what actually remains.
+		p.log.WithFields(logrus.Fields{
+			labelNetwork: network,
+			"from":       state.lastProcessedEpoch + 1,
+			"skipped_to": target,
+		}).Warn("Skipping the epoch backlog spanning a network identity change")
+
+		state.lastProcessedEpoch = target
+	}
+
+	from := state.lastProcessedEpoch + 1
+	if !state.seen {
 		oldest, oerr := p.edgeBlock(ctx, network, orderSlotAsc)
 		if oerr != nil || oldest == nil {
 			return oerr
 		}
 
-		from = uint64(oldest.Epoch) //nolint:gosec // slots/epochs are non-negative
+		from = uint64(oldest.Epoch) //nolint:gosec // epochs are non-negative
 	}
 
-	for epoch := from; epoch <= target; epoch++ {
+	if from > target {
+		return nil
+	}
+
+	last := target
+	if last-from >= maxEpochsPerTick {
+		last = from + maxEpochsPerTick - 1
+
+		p.log.WithFields(logrus.Fields{
+			labelNetwork: network,
+			"from":       from,
+			"until":      last,
+			"target":     target,
+		}).Info("Epoch backlog exceeds one tick's budget; draining over subsequent ticks")
+	}
+
+	for epoch := from; epoch <= last; epoch++ {
 		if err := p.processEpoch(ctx, network, epoch, headSlot); err != nil {
 			// Hold the epoch back and retry next tick - the existence
 			// probe makes re-processing free - but only boundedly: a
 			// deterministic poison candidate must not block every later
 			// epoch until the reaper eats them.
-			retry := p.retries[network]
+			retry := state.retry
 			if retry == nil || retry.epoch != epoch {
 				retry = &epochRetry{epoch: epoch}
-				p.retries[network] = retry
+				state.retry = retry
 			}
 
 			retry.attempts++
@@ -237,17 +356,79 @@ func (p *Promoter) processNetwork(ctx context.Context, network string) error {
 				return errors.Wrapf(err, "failed to process epoch %d (attempt %d/%d)", epoch, retry.attempts, maxEpochAttempts)
 			}
 
-			p.log.WithError(err).WithFields(logrus.Fields{labelNetwork: network, "epoch": epoch}).Error("Abandoning epoch after repeated failures; its unpromoted captures are lost")
+			p.log.WithError(err).WithFields(logrus.Fields{labelNetwork: network, labelEpoch: epoch}).Error("Abandoning epoch after repeated failures; its unpromoted captures are lost")
 			p.metrics.ObserveError(network)
 		}
 
-		delete(p.retries, network)
+		state.retry = nil
+		state.lastProcessedEpoch = epoch
+		state.seen = true
 
-		p.lastProcessedEpoch[network] = epoch
 		p.metrics.ObserveLastProcessedEpoch(network, epoch)
 	}
 
 	return nil
+}
+
+// headEpoch reads the head row's epoch, cross-checked against its slot. The
+// epoch column is agent-computed, so one mis-indexed row could otherwise drag
+// the cursor into epochs that will never exist and stall the service until
+// the row is reaped. The configured spec is the only cross-check available
+// server-side; a persistent complaint here means slotsPerEpoch is wrong for
+// this network, which would also make the retention check wrong.
+func (p *Promoter) headEpoch(network string, head *persistence.BeaconBlock) uint64 {
+	headEpoch, headSlot := uint64(head.Epoch), uint64(head.Slot) //nolint:gosec // slots/epochs are non-negative
+
+	plausible := headSlot/p.config.SlotsPerEpoch + 1
+	if headEpoch <= plausible {
+		return headEpoch
+	}
+
+	p.log.WithFields(logrus.Fields{
+		labelNetwork: network,
+		"head_epoch": headEpoch,
+		labelSlot:    headSlot,
+		"clamped_to": plausible,
+	}).Error("Indexed head epoch is implausible for its slot; clamping. Check that promotion slotsPerEpoch matches the network")
+	p.metrics.ObserveSkip(network, SkipReasonImplausibleEpoch)
+
+	return plausible
+}
+
+// refreshIdentity re-resolves the network's genesis validators root when the
+// cached one has aged out, and reports whether it changed. A changed GVR
+// means this name now denotes a different chain: pinning the first one for
+// the process lifetime would file every later block-only capture under a
+// network that no longer exists.
+func (p *Promoter) refreshIdentity(ctx context.Context, network string, state *networkState) bool {
+	if state.gvr != "" && time.Since(state.gvrResolved) < networkIdentityTTL {
+		return false
+	}
+
+	gvr := p.resolveNetworkGVR(ctx, network)
+	if gvr == "" {
+		return false
+	}
+
+	previous := state.gvr
+	changed := previous != "" && previous != gvr
+
+	if changed {
+		p.log.WithFields(logrus.Fields{
+			labelNetwork:   network,
+			"previous_gvr": previous,
+			"current_gvr":  gvr,
+		}).Warn("Network genesis validators root changed; the name now denotes a different chain")
+
+		state.retry = nil
+
+		p.metrics.ObserveNetworkReset(network, ResetReasonIdentityChange)
+	}
+
+	state.gvr = gvr
+	state.gvrResolved = time.Now()
+
+	return changed
 }
 
 func (p *Promoter) edgeBlock(ctx context.Context, network, order string) (*persistence.BeaconBlock, error) {
@@ -281,9 +462,20 @@ type epochPass struct {
 	byRoot map[string]*candidate
 	slots  []uint64
 
+	// firstIndexedSlot is the lowest slot the index holds for this epoch,
+	// before any object load succeeded or failed. The baseline trigger
+	// keys off it so that an unfetchable block cannot slide the baseline
+	// onto a different slot between scans.
+	firstIndexedSlot uint64
+
 	// children holds every parent_root referenced by a candidate in this
 	// pass: deterministic evidence for canonical-branch resolution.
 	children map[string]bool
+
+	// lookahead caches the parent roots referenced by the next epoch's
+	// earliest blocks, resolved at most once per pass.
+	lookahead       map[string]bool
+	lookaheadLoaded bool
 }
 
 func (p *Promoter) processEpoch(ctx context.Context, network string, epoch, headSlot uint64) error {
@@ -296,13 +488,25 @@ func (p *Promoter) processEpoch(ctx context.Context, network string, epoch, head
 		return nil
 	}
 
+	if len(rows) == epochRowLimit {
+		// The listing was truncated, which is indistinguishable downstream
+		// from an epoch that simply had fewer blocks. Say so.
+		p.metrics.ObserveSkip(network, SkipReasonRowLimit)
+		p.log.WithFields(logrus.Fields{
+			labelNetwork: network,
+			labelEpoch:   epoch,
+			"limit":      epochRowLimit,
+		}).Warn("Epoch listing hit the row limit; some captures in this epoch are not considered")
+	}
+
 	pass := &epochPass{
-		network:  network,
-		epoch:    epoch,
-		headSlot: headSlot,
-		bySlot:   make(map[uint64][]*candidate),
-		byRoot:   make(map[string]*candidate),
-		children: make(map[string]bool),
+		network:          network,
+		epoch:            epoch,
+		headSlot:         headSlot,
+		bySlot:           make(map[uint64][]*candidate),
+		byRoot:           make(map[string]*candidate),
+		children:         make(map[string]bool),
+		firstIndexedSlot: firstIndexedSlot(rows),
 	}
 
 	p.buildCandidates(ctx, pass, rows)
@@ -339,6 +543,25 @@ func (p *Promoter) processEpoch(ctx context.Context, network string, epoch, head
 	}
 
 	return failed
+}
+
+// firstIndexedSlot returns the lowest non-negative slot among the rows.
+func firstIndexedSlot(rows []*persistence.BeaconBlock) uint64 {
+	first := uint64(0)
+	found := false
+
+	for _, row := range rows {
+		if row.Slot < 0 {
+			continue
+		}
+
+		slot := uint64(row.Slot)
+		if !found || slot < first {
+			first, found = slot, true
+		}
+	}
+
+	return first
 }
 
 // buildCandidates fetches every distinct root's bytes once and byte-peeks the
@@ -389,6 +612,8 @@ func (p *Promoter) buildCandidates(ctx context.Context, pass *epochPass, rows []
 
 // loadCandidate fetches, decompresses and peeks a block from any node's copy.
 func (p *Promoter) loadCandidate(ctx context.Context, network string, cand *candidate, rows []*persistence.BeaconBlock) bool {
+	malformed := false
+
 	for _, row := range rows {
 		data, err := p.buffer.GetBeaconBlock(ctx, row.Location)
 		if err != nil || data == nil {
@@ -397,6 +622,8 @@ func (p *Promoter) loadCandidate(ctx context.Context, network string, cand *cand
 
 		raw, err := decompress(*data, row.ContentEncoding)
 		if err != nil {
+			malformed = true
+
 			p.log.WithError(err).WithField("location", row.Location).Warn("Failed to decompress block")
 
 			continue
@@ -406,7 +633,8 @@ func (p *Promoter) loadCandidate(ctx context.Context, network string, cand *cand
 		if err != nil || peek.Slot != cand.slot {
 			// Truncated or misfiled: promote nothing under a label the
 			// payload contradicts.
-			p.metrics.ObserveSkip(network, SkipReasonMalformed)
+			malformed = true
+
 			p.log.WithError(err).WithFields(logrus.Fields{"location": row.Location, labelSlot: cand.slot}).Warn("Block bytes fail sanity rules")
 
 			continue
@@ -420,14 +648,24 @@ func (p *Promoter) loadCandidate(ctx context.Context, network string, cand *cand
 		return true
 	}
 
-	p.metrics.ObserveSkip(network, SkipReasonMissingObject)
+	// One skip per candidate, attributed to what actually went wrong: bytes
+	// we could not trust, or bytes we could not find.
+	if malformed {
+		p.metrics.ObserveSkip(network, SkipReasonMalformed)
+	} else {
+		p.metrics.ObserveSkip(network, SkipReasonMissingObject)
+	}
 
 	return false
 }
 
-// baselineSlot returns the first qualifying slot of a baseline epoch. It is a
-// pure function of the epoch number so re-processing selects the same slots.
-// Requires pass.slots to be sorted.
+// baselineSlot returns the baseline slot of a baseline epoch: the lowest slot
+// the INDEX holds for it, not the lowest slot that happened to load. Which
+// epochs fire is a pure function of the epoch number, and which slot fires is
+// a pure function of the index, so a rescan selects the same capture. Keying
+// off the loaded set instead would slide the baseline onto a neighbouring
+// slot whenever an object became unfetchable, promoting a second baseline for
+// an epoch that already had one.
 func (p *Promoter) baselineSlot(pass *epochPass) (uint64, bool) {
 	if !triggerEnabled(p.config.Triggers.Baseline) || p.config.BaselineEveryNEpochs == 0 {
 		return 0, false
@@ -437,7 +675,9 @@ func (p *Promoter) baselineSlot(pass *epochPass) (uint64, bool) {
 		return 0, false
 	}
 
-	return pass.slots[0], true
+	// The block at that slot may be unloadable, in which case this epoch
+	// simply has no baseline - deterministically.
+	return pass.firstIndexedSlot, true
 }
 
 // parentInfo is everything known about a candidate's parent, resolved by
@@ -566,8 +806,23 @@ func (p *Promoter) resolveBranches(ctx context.Context, pass *epochPass, cands [
 }
 
 // lookaheadChildren byte-peeks the earliest blocks of the next epoch and
-// returns the set of parent roots they reference.
+// returns the set of parent roots they reference. The result is cached on the
+// pass: every reorged slot in an epoch asks the same question, and answering
+// it costs a query plus up to 20 block fetches.
 func (p *Promoter) lookaheadChildren(ctx context.Context, pass *epochPass) map[string]bool {
+	if pass.lookaheadLoaded {
+		return pass.lookahead
+	}
+
+	out := p.fetchLookaheadChildren(ctx, pass)
+
+	pass.lookahead = out
+	pass.lookaheadLoaded = true
+
+	return out
+}
+
+func (p *Promoter) fetchLookaheadChildren(ctx context.Context, pass *epochPass) map[string]bool {
 	out := make(map[string]bool)
 	next := pass.epoch + 1
 
@@ -604,23 +859,24 @@ func (p *Promoter) lookaheadChildren(ctx context.Context, pass *epochPass) map[s
 	return out
 }
 
-// rateTier classifies a capture for admission. Reorgs are uncapped: they are
-// self-limiting per slot and the orphaned branch is unobtainable anywhere
-// else. Rare-but-not-bounded classes (slashings can arrive by the hundreds
-// in a mass-slashing incident) get their own budget so they never compete
-// with a participation/gap flood, yet keep a hard ceiling. Everything
-// repetitive or spammable draws from the common budget.
+// rateTier classifies a capture for admission. Reorgs get their own, very
+// generous budget: they are self-limiting per slot and the orphaned branch is
+// unobtainable anywhere else, but per-slot self-limiting is not a bound in
+// aggregate. Rare-but-not-bounded classes (slashings can arrive by the
+// hundreds in a mass-slashing incident) get a budget of their own so they
+// never compete with a participation/gap flood, yet keep a hard ceiling.
+// Everything repetitive or spammable draws from the common budget.
 type rateTier int
 
 const (
-	tierUncapped rateTier = iota
+	tierReorg rateTier = iota
 	tierRare
 	tierCommon
 )
 
 func classifyTier(triggers []string) rateTier {
 	if slices.Contains(triggers, TriggerReorg) {
-		return tierUncapped
+		return tierReorg
 	}
 
 	for _, trigger := range triggers {
@@ -633,26 +889,38 @@ func classifyTier(triggers []string) rateTier {
 	return tierCommon
 }
 
-func (p *Promoter) window(network string) *rateWindow {
+// skipReason names the metric label for a tier that ran out of budget.
+func (t rateTier) skipReason() string {
+	switch t {
+	case tierReorg:
+		return SkipReasonRateCappedReorg
+	case tierRare:
+		return SkipReasonRateCappedRare
+	default:
+		return SkipReasonRateCappedCommon
+	}
+}
+
+// window returns the network's current hourly budget, rolling it over when
+// the previous one has expired. The window is tumbling, not sliding.
+func (p *Promoter) window(state *networkState) *rateWindow {
 	now := time.Now()
 
-	w := p.rate[network]
-	if w == nil || now.Sub(w.start) >= time.Hour {
-		w = &rateWindow{start: now}
-		p.rate[network] = w
+	if state.rate.start.IsZero() || now.Sub(state.rate.start) >= time.Hour {
+		state.rate = rateWindow{start: now}
 	}
 
-	return w
+	return &state.rate
 }
 
 // headroom reports whether the tier's per-network hourly budget has room,
 // without consuming any.
-func (p *Promoter) headroom(network string, tier rateTier) bool {
-	w := p.window(network)
+func (p *Promoter) headroom(state *networkState, tier rateTier) bool {
+	w := p.window(state)
 
 	switch tier {
-	case tierUncapped:
-		return true
+	case tierReorg:
+		return w.reorgCount < p.config.ReorgCapPerHour
 	case tierRare:
 		return w.rareCount < p.config.RareCapPerHour
 	default:
@@ -662,13 +930,16 @@ func (p *Promoter) headroom(network string, tier rateTier) bool {
 
 // consume takes one promotion from the tier's hourly budget. When a budget
 // is exhausted the caller skips - it never queues and never deletes.
-func (p *Promoter) consume(network string, tier rateTier) {
+func (p *Promoter) consume(state *networkState, tier rateTier) {
+	w := p.window(state)
+
 	switch tier {
-	case tierUncapped:
+	case tierReorg:
+		w.reorgCount++
 	case tierRare:
-		p.window(network).rareCount++
+		w.rareCount++
 	default:
-		p.window(network).commonCount++
+		w.commonCount++
 	}
 }
 
@@ -679,20 +950,21 @@ func (p *Promoter) consume(network string, tier rateTier) {
 // cap is consulted, so a restart-rescan of the retained window is free and
 // never burns the hourly budget on captures the corpus already has.
 func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate, parent parentInfo, triggers []string, branch string) error {
-	forkName := "unknown"
+	forkName := unknownComponent
 	if cand.decoded != nil {
 		forkName = cand.decoded.Version.String()
 	}
 
 	id := captureID(cand.slot, cand.root)
 	tier := classifyTier(triggers)
+	state := p.network(pass.network)
 
 	// Provisional dedupe with the cached network GVR: on a rescan this
 	// skips the capture before any state-sized fetch happens.
 	provisionalKey := ""
 
-	if gvr := p.resolveNetworkGVR(ctx, pass.network); gvr != "" {
-		provisionalKey = capturePath(networkID(pass.network, gvr), forkName, id, captureManifestName)
+	if state.gvr != "" {
+		provisionalKey = capturePath(networkID(pass.network, state.gvr), forkName, id, captureManifestName)
 		if exists, err := p.corpus.Exists(ctx, provisionalKey); err == nil && exists {
 			p.metrics.ObserveSkip(pass.network, SkipReasonAlreadyPromoted)
 
@@ -702,11 +974,8 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 
 	// Cheap headroom probe before the state fetch; the budget is only
 	// consumed once the capture is known to be new.
-	if !p.headroom(pass.network, tier) {
-		reason := SkipReasonRateCappedCommon
-		if tier == tierRare {
-			reason = SkipReasonRateCappedRare
-		}
+	if !p.headroom(state, tier) {
+		reason := tier.skipReason()
 
 		p.metrics.ObserveSkip(pass.network, reason)
 		p.log.WithFields(logrus.Fields{labelNetwork: pass.network, labelSlot: cand.slot, labelBlockRoot: cand.root, "tier": reason}).Debug("Rate cap exhausted, skipping promotion")
@@ -723,7 +992,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 		expectedStateRoot = normHex(parent.peek.StateRoot.String())
 	}
 
-	stateRaw, prestate := p.resolvePrestate(ctx, pass.network, parent, expectedStateRoot)
+	stateRaw, prestate := p.resolvePrestate(ctx, pass.network, state, parent, expectedStateRoot)
 
 	gvr := ""
 
@@ -739,7 +1008,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 		// in the buffer. Without one the capture cannot be filed under an
 		// unambiguous network id, and a wrong prefix mixes incompatible
 		// chains - skip, visibly.
-		gvr = p.resolveNetworkGVR(ctx, pass.network)
+		gvr = state.gvr
 		if gvr == "" {
 			p.metrics.ObserveSkip(pass.network, SkipReasonGVRAmbiguous)
 			p.log.WithFields(logrus.Fields{labelNetwork: pass.network, labelSlot: cand.slot}).Warn("No genesis validators root resolvable; refusing to label capture")
@@ -748,8 +1017,11 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 		}
 	}
 
-	if p.networkGVR[pass.network] == "" {
-		p.networkGVR[pass.network] = gvr
+	// A paired state is first-hand evidence of the network's identity, so
+	// it seeds the cache when the periodic refresh has nothing yet.
+	if state.gvr == "" {
+		state.gvr = gvr
+		state.gvrResolved = time.Now()
 	}
 
 	network := networkID(pass.network, gvr)
@@ -827,7 +1099,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 	// The manifest is the commit point: budget is only consumed once the
 	// capture actually landed, so a corpus-store outage cannot burn the
 	// hourly window on failed writes.
-	p.consume(pass.network, tier)
+	p.consume(state, tier)
 
 	p.metrics.ObserveCorpusBytes(pass.network, "manifest", len(data))
 	p.metrics.ObserveCapture(pass.network, branch)
@@ -856,7 +1128,7 @@ func (p *Promoter) promote(ctx context.Context, pass *epochPass, cand *candidate
 // When the parent block's own state_root is known, only the branch-exact row
 // qualifies; without it, a slot-level fallback is accepted but the pairing
 // stays unverified and must at least be GVR-consistent with the network.
-func (p *Promoter) resolvePrestate(ctx context.Context, network string, parent parentInfo, expectedStateRoot string) ([]byte, *ManifestPrestate) {
+func (p *Promoter) resolvePrestate(ctx context.Context, network string, state *networkState, parent parentInfo, expectedStateRoot string) ([]byte, *ManifestPrestate) {
 	if !parent.known {
 		return nil, nil
 	}
@@ -895,7 +1167,7 @@ func (p *Promoter) resolvePrestate(ctx context.Context, network string, parent p
 			// whose GVR contradicts the network to avoid mixing recreated
 			// chains under one prefix.
 			gvr := normHex(peek.GenesisValidatorsRoot.String())
-			if known := p.networkGVR[network]; known != "" && known != gvr {
+			if state.gvr != "" && state.gvr != gvr {
 				p.metrics.ObserveSkip(network, SkipReasonGVRAmbiguous)
 
 				continue
@@ -931,13 +1203,12 @@ func (p *Promoter) writeState(ctx context.Context, network string, raw []byte, s
 	return nil
 }
 
-// resolveNetworkGVR resolves a network's genesis validators root from any
-// retained state, cached per network name for the process lifetime.
+// resolveNetworkGVR reads a network's genesis validators root from its
+// freshest retained state. Freshest, not any: after a devnet is recreated
+// under the same name the buffer briefly holds both chains, and the newest
+// state is the one that says which chain the name means now. Caching is the
+// caller's business - see refreshIdentity.
 func (p *Promoter) resolveNetworkGVR(ctx context.Context, network string) string {
-	if gvr := p.networkGVR[network]; gvr != "" {
-		return gvr
-	}
-
 	rows, err := p.db.ListBeaconState(ctx, &persistence.BeaconStateFilter{Network: &network}, &persistence.PaginationCursor{Limit: 5, OrderBy: "fetched_at DESC"})
 	if err != nil {
 		return ""
@@ -955,10 +1226,7 @@ func (p *Promoter) resolveNetworkGVR(ctx context.Context, network string) string
 		}
 
 		if peek, perr := peekState(raw); perr == nil {
-			gvr := normHex(peek.GenesisValidatorsRoot.String())
-			p.networkGVR[network] = gvr
-
-			return gvr
+			return normHex(peek.GenesisValidatorsRoot.String())
 		}
 	}
 

--- a/pkg/server/service/promotion/promotion_test.go
+++ b/pkg/server/service/promotion/promotion_test.go
@@ -2,6 +2,7 @@ package promotion
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +173,57 @@ func TestRateCap(t *testing.T) {
 	}
 
 	assert.Equal(t, map[uint64]int{163: 1, 166: 1, 167: 2}, slots)
+}
+
+// A failed corpus write consumes no rate budget and holds the epoch back for
+// retry: after the store recovers, the capture is promoted with the budget
+// intact.
+func TestFailedWriteConsumesNoBudgetAndRetries(t *testing.T) {
+	e := newEnv(t, func(c *Config) { c.RateCapPerHour = 1 })
+	gvr := fillRoot(0x11)
+
+	e.seedChain(gvr, 160, 163)
+	e.seedHeadAnchor(224)
+
+	// Corpus outage: every write fails.
+	require.NoError(t, os.Chmod(e.corpusDir, 0o555))
+
+	e.promoter.tick(t.Context())
+	assert.Empty(t, e.findManifests())
+
+	// Recovery: the held-back epoch is retried and the (unconsumed) budget
+	// admits the capture.
+	require.NoError(t, os.Chmod(e.corpusDir, 0o755))
+
+	e.promoter.tick(t.Context())
+	require.Len(t, e.findManifests(), 1)
+}
+
+// A persistently failing epoch is retried boundedly, then abandoned loudly -
+// one poison candidate must not block every later epoch until the reaper
+// eats them.
+func TestFailingEpochIsAbandonedAfterBoundedRetries(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+
+	e.seedChain(gvr, 160, 163)
+	e.seedHeadAnchor(224)
+
+	require.NoError(t, os.Chmod(e.corpusDir, 0o555))
+
+	for range maxEpochAttempts {
+		e.promoter.tick(t.Context())
+	}
+
+	// The epoch was abandoned and progress advanced past it.
+	assert.Equal(t, uint64(5), e.promoter.lastProcessedEpoch[testNetwork])
+
+	// Even after recovery the abandoned capture is not retried (until a
+	// restart rescan); nothing was promoted.
+	require.NoError(t, os.Chmod(e.corpusDir, 0o755))
+
+	e.promoter.tick(t.Context())
+	assert.Empty(t, e.findManifests())
 }
 
 // After a restart-rescan, cap budget is NOT spent on captures that already

--- a/pkg/server/service/promotion/promotion_test.go
+++ b/pkg/server/service/promotion/promotion_test.go
@@ -133,6 +133,59 @@ func TestIdempotency(t *testing.T) {
 	assert.Equal(t, before, e.corpusFiles())
 }
 
+// Rare-tier triggers (slashing etc.) draw from their own budget: a
+// participation/gap flood that exhausts the common cap never crowds out the
+// rarest captures.
+func TestRareTriggerBeatsCommonFlood(t *testing.T) {
+	e := newEnv(t, func(c *Config) { c.RateCapPerHour = 1 })
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	// 163 (gap) consumes the entire common budget; 168 (gap) is capped.
+	e.seedChain(gvr, 160, 163, 164, 165, 168)
+
+	// A slashing at 166 arrives mid-flood.
+	e.seedBlock(testNode, 166, 5, slotRoot(0xe1, 166), testBlock(t, 166, blockRootFor(165), slotRoot(0xb1, 166), withAttesterSlashing), now)
+	e.seedState(testNode, 166, slotRoot(0xb1, 166), testState(gvr, 166), now)
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	slots := map[uint64][]string{}
+
+	for _, path := range e.findManifests() {
+		m := e.readManifest(path)
+		slots[m.Block.Slot] = m.Promotion.Triggers
+	}
+
+	assert.Contains(t, slots, uint64(163), "common budget goes to the first gap")
+	assert.NotContains(t, slots, uint64(168), "second gap must be rate capped")
+	require.Contains(t, slots, uint64(166), "slashing must not compete with the flood")
+	assert.Equal(t, []string{TriggerSlashing}, slots[166])
+}
+
+// The rare tier has its own hard ceiling: a mass-slashing incident cannot
+// flood the corpus either.
+func TestRareCapCeiling(t *testing.T) {
+	e := newEnv(t, func(c *Config) { c.RareCapPerHour = 1 })
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	e.seedChain(gvr, 160)
+
+	for _, slot := range []uint64{161, 162} {
+		e.seedBlock(testNode, slot, 5, slotRoot(0xe1, slot), testBlock(t, slot, blockRootFor(slot-1), slotRoot(0xb1, slot), withAttesterSlashing), now)
+		e.seedState(testNode, slot, slotRoot(0xb1, slot), testState(gvr, slot), now)
+	}
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+	assert.Equal(t, uint64(161), e.readManifest(manifests[0]).Block.Slot)
+}
+
 // The rate cap skips (never queues, never deletes); reorg promotions bypass
 // it; a rescan does not burn budget on already-promoted captures.
 func TestRateCap(t *testing.T) {

--- a/pkg/server/service/promotion/promotion_test.go
+++ b/pkg/server/service/promotion/promotion_test.go
@@ -239,6 +239,7 @@ func TestFailedWriteConsumesNoBudgetAndRetries(t *testing.T) {
 	e.seedHeadAnchor(224)
 
 	// Corpus outage: every write fails.
+	requireWriteProtectable(t)
 	require.NoError(t, os.Chmod(e.corpusDir, 0o555))
 
 	e.promoter.tick(t.Context())
@@ -262,6 +263,7 @@ func TestFailingEpochIsAbandonedAfterBoundedRetries(t *testing.T) {
 	e.seedChain(gvr, 160, 163)
 	e.seedHeadAnchor(224)
 
+	requireWriteProtectable(t)
 	require.NoError(t, os.Chmod(e.corpusDir, 0o555))
 
 	for range maxEpochAttempts {
@@ -269,7 +271,7 @@ func TestFailingEpochIsAbandonedAfterBoundedRetries(t *testing.T) {
 	}
 
 	// The epoch was abandoned and progress advanced past it.
-	assert.Equal(t, uint64(5), e.promoter.lastProcessedEpoch[testNetwork])
+	assert.Equal(t, uint64(5), e.promoter.network(testNetwork).lastProcessedEpoch)
 
 	// Even after recovery the abandoned capture is not retried (until a
 	// restart rescan); nothing was promoted.
@@ -481,6 +483,156 @@ func TestTriggerToggle(t *testing.T) {
 	assert.Empty(t, e.findManifests())
 }
 
+// A devnet recreated under the same name restarts at slot 0. The cursor only
+// ever moves forward, so without noticing the lost height the service would
+// sit above every real epoch and silently promote nothing until restart.
+func TestNetworkResetOnHeightRegression(t *testing.T) {
+	e := newEnv(t, nil)
+
+	// Chain A, epoch 5.
+	e.seedChain(fillRoot(0x11), 160, 163)
+	e.seedHeadAnchor(224)
+
+	e.promoter.tick(t.Context())
+	require.Len(t, e.findManifests(), 1)
+	require.Equal(t, uint64(5), e.promoter.network(testNetwork).lastProcessedEpoch)
+
+	// The devnet is torn down and recreated under the same name: slots
+	// restart at 0 and the reaper clears chain A.
+	e.purge()
+
+	gvrB := fillRoot(0x22)
+	e.seedChain(gvrB, 0, 1, 32, 35)
+	e.seedHeadAnchor(96) // epoch 3 -> target 1
+
+	e.promoter.tick(t.Context())
+
+	state := e.promoter.network(testNetwork)
+	assert.Equal(t, uint64(1), state.lastProcessedEpoch, "cursor must follow the chain down")
+	assert.Equal(t, normHex(gvrB.String()), state.gvr, "identity must follow the new chain")
+
+	// Chain B's captures land, under chain B's name.
+	networks := map[string]bool{}
+
+	for _, path := range e.findManifests() {
+		networks[e.readManifest(path).Network.Name] = true
+	}
+
+	assert.True(t, networks[testNetwork+"-22222222"], "chain B must be promoted, got %v", networks)
+}
+
+// When the identity changes while the buffer may still hold both chains, the
+// backlog is skipped rather than relabelled: block-only promotions take their
+// network id from the cache, so rescanning it would file the old chain's
+// blocks under the new chain's name.
+func TestIdentityChangeSkipsAmbiguousBacklog(t *testing.T) {
+	e := newEnv(t, nil)
+
+	e.seedChain(fillRoot(0x11), 160, 163)
+	e.seedHeadAnchor(224)
+
+	e.promoter.tick(t.Context())
+	require.Len(t, e.findManifests(), 1)
+
+	before := e.corpusFiles()
+
+	// A newer state from a different chain appears under the same name,
+	// while the old chain still holds the highest slots.
+	gvrB := fillRoot(0x22)
+	e.seedState(testNode, 300, slotRoot(0xb2, 300), testState(gvrB, 300), time.Now().Add(time.Hour))
+
+	// Epoch 6 has a gap-triggered, block-only candidate: exactly the shape
+	// that takes its network id from the cache.
+	e.seedBlock(testNode, 192, 6, blockRootFor(192), testBlock(t, 192, blockRootFor(163), stateRootFor(192), nil), time.Now())
+	e.seedHeadAnchor(256) // epoch 8 -> target 6
+
+	e.expireIdentity()
+	e.promoter.tick(t.Context())
+
+	state := e.promoter.network(testNetwork)
+	assert.Equal(t, normHex(gvrB.String()), state.gvr)
+	assert.Equal(t, uint64(6), state.lastProcessedEpoch, "the ambiguous backlog is skipped, not rescanned")
+	assert.Equal(t, before, e.corpusFiles(), "nothing from the old chain may be relabelled")
+}
+
+// One mis-indexed row must not drag the cursor into epochs that will never
+// exist: the epoch column is agent-computed, so it is cross-checked against
+// the head slot before it becomes the target.
+func TestImplausibleHeadEpochIsClamped(t *testing.T) {
+	e := newEnv(t, nil)
+
+	e.seedChain(fillRoot(0x11), 160, 163)
+	e.seedHeadAnchor(224)
+
+	// A row claiming an absurd epoch for a modest slot.
+	e.insertBlockRow(testNode, 225, 1_000_000, blockRootFor(225).String(), "missing/location", time.Now())
+
+	e.promoter.tick(t.Context())
+
+	// Bounded by the head slot, not by the bogus epoch.
+	assert.LessOrEqual(t, e.promoter.network(testNetwork).lastProcessedEpoch, uint64(8))
+	assert.Len(t, e.findManifests(), 1)
+}
+
+// A cold start over a long window drains across ticks instead of running one
+// unbounded tick.
+func TestEpochBacklogIsBoundedPerTick(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+
+	e.seedChain(gvr, 0)
+	e.seedHeadAnchor(uint64(maxEpochsPerTick+4) * 32)
+
+	e.promoter.tick(t.Context())
+	assert.Equal(t, uint64(maxEpochsPerTick-1), e.promoter.network(testNetwork).lastProcessedEpoch)
+
+	e.promoter.tick(t.Context())
+	assert.Equal(t, uint64(maxEpochsPerTick+2), e.promoter.network(testNetwork).lastProcessedEpoch)
+}
+
+// The baseline slot is chosen from the index, not from whichever blocks
+// happened to load, so an unfetchable block cannot slide the baseline onto a
+// neighbouring slot and promote a second baseline for the same epoch.
+func TestBaselineDoesNotSlideOnUnloadableBlock(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+
+	// Epoch 8 (8%8 == 0). The lowest indexed slot has no object behind it.
+	e.insertBlockRow(testNode, 256, 8, blockRootFor(256).String(), "missing/location", time.Now())
+	e.seedChain(gvr, 257, 258)
+	e.seedHeadAnchor(320)
+
+	e.promoter.tick(t.Context())
+
+	// No baseline at all rather than a baseline at the wrong slot.
+	for _, path := range e.findManifests() {
+		assert.NotContains(t, e.readManifest(path).Promotion.Triggers, TriggerBaseline)
+	}
+}
+
+// Reorg promotions have their own budget rather than no budget: per-slot
+// self-limiting is not a bound in aggregate.
+func TestReorgCapCeiling(t *testing.T) {
+	e := newEnv(t, func(c *Config) { c.ReorgCapPerHour = 2 })
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	e.seedChain(gvr, 160)
+
+	// Two reorged slots, four branches, budget for two.
+	for _, slot := range []uint64{161, 162} {
+		for _, kind := range []byte{0xe1, 0xe2} {
+			e.seedBlock(testNode, slot, 5, slotRoot(kind, slot),
+				testBlock(t, slot, blockRootFor(160), slotRoot(kind, slot), nil), now)
+		}
+	}
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	assert.Len(t, e.findManifests(), 2)
+}
+
 func TestCaptureID(t *testing.T) {
 	id := captureID(384, "0xdeadbeefcafebabe0000000000000000000000000000000000000000000000ff")
 	assert.Equal(t, "000000384-deadbeefcafe", id)
@@ -491,4 +643,16 @@ func TestCaptureID(t *testing.T) {
 
 func TestNetworkID(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s-2093236b", testNetwork), networkID(testNetwork, "0x2093236b11223344"))
+}
+
+// The network name arrives from an agent and ends up in an object key; the
+// filesystem store resolves "../" the way filesystems do.
+func TestNetworkIDSanitisesTraversal(t *testing.T) {
+	assert.Equal(t, ".._.._etc-2093236b", networkID("../../etc", "0x2093236b11223344"))
+	assert.Equal(t, "unknown-2093236b", networkID("..", "0x2093236b11223344"))
+	assert.Equal(t, "unknown-2093236b", networkID("", "0x2093236b11223344"))
+
+	path := capturePath(networkID("../../etc", "0x2093236b"), "electra", "000000001-aa", captureManifestName)
+	assert.NotContains(t, path, "../")
+	assert.True(t, strings.HasPrefix(path, corpusCapturePrefix+"/"))
 }

--- a/pkg/server/service/promotion/promotion_test.go
+++ b/pkg/server/service/promotion/promotion_test.go
@@ -1,0 +1,389 @@
+package promotion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Pairing across skipped slots: the pre-state is the post-state of the
+// block's PARENT, resolved by parent_root - never slot-1.
+func TestPairingAcrossSkippedSlots(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+
+	// Epoch 5: parent at 160, child at 163; slots 161-162 skipped.
+	raws := e.seedChain(gvr, 160, 163)
+	e.seedHeadAnchor(224) // epoch 7 -> target epoch 5
+
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+
+	m := e.readManifest(manifests[0])
+	assert.Equal(t, uint64(163), m.Block.Slot)
+	assert.Contains(t, m.Promotion.Triggers, TriggerGap)
+	assert.True(t, m.Promotion.Decoded)
+	assert.Equal(t, "altair", m.Fork.Name)
+	assert.Equal(t, BranchCanonical, m.Promotion.Branch)
+	assert.Equal(t, testNetwork+"-11111111", m.Network.Name)
+	assert.Equal(t, testNetwork, m.Network.ConfigName)
+	assert.Equal(t, normHex(gvr.String()), m.Network.GenesisValidatorsRoot)
+
+	// Paired with the parent's post-state at slot 160, not slot 162.
+	require.NotNil(t, m.Prestate)
+	assert.Equal(t, uint64(160), m.Prestate.Slot)
+	assert.True(t, m.Promotion.PairVerified)
+	assert.Equal(t, testNode, m.Prestate.SourceNode)
+
+	// expected_state_root is the PARENT block's own state_root - not the
+	// candidate's, which is the child's POST-state root.
+	assert.Equal(t, normHex(stateRootFor(160).String()), m.Prestate.ExpectedStateRoot)
+	assert.NotEqual(t, m.Block.StateRoot, m.Prestate.ExpectedStateRoot)
+
+	// Digests are computed over the decompressed bytes, and corpus objects
+	// are byte-identical to what the node served, stored uncompressed.
+	stateRaw := testState(gvr, 160)
+	assert.Equal(t, sha256Hex(stateRaw), m.Prestate.SHA256)
+	assert.Equal(t, len(stateRaw), m.Prestate.Size)
+	assert.Equal(t, stateRaw, e.readCorpusObject(statePath(m.Prestate.SHA256)))
+
+	blockPath := strings.TrimSuffix(manifests[0], captureManifestName) + captureBlockName
+	assert.Equal(t, raws[163], e.readCorpusObject(blockPath))
+	assert.Equal(t, sha256Hex(raws[163]), m.Block.SHA256)
+}
+
+// A reorg promotes BOTH branches; capture ids do not collide; the branch
+// referenced by a later block is canonical.
+func TestReorgPromotesBothBranches(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	e.seedChain(gvr, 160, 161)
+
+	// Two branches at 162, both children of 161.
+	rootB, rootC := slotRoot(0xe1, 162), slotRoot(0xe2, 162)
+	e.seedBlock(testNode, 162, 5, rootB, testBlock(t, 162, blockRootFor(161), slotRoot(0xb1, 162), nil), now.Add(time.Second))
+	e.seedBlock("cl-2-test", 162, 5, rootC, testBlock(t, 162, blockRootFor(161), slotRoot(0xb2, 162), nil), now)
+
+	// A child at 163 extends rootB: deterministic canonicality evidence.
+	e.seedBlock(testNode, 163, 5, blockRootFor(163), testBlock(t, 163, rootB, stateRootFor(163), nil), now)
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 2)
+
+	branches := map[string]string{}
+
+	for _, path := range manifests {
+		m := e.readManifest(path)
+		assert.Equal(t, uint64(162), m.Block.Slot)
+		assert.Contains(t, m.Promotion.Triggers, TriggerReorg)
+
+		// Both branches pair against the SAME parent state at 161.
+		require.NotNil(t, m.Prestate)
+		assert.Equal(t, uint64(161), m.Prestate.Slot)
+		assert.Equal(t, sha256Hex(testState(gvr, 161)), m.Prestate.SHA256)
+
+		branches[m.Block.Root] = m.Promotion.Branch
+	}
+
+	assert.Equal(t, BranchCanonical, branches[normHex(rootB.String())])
+	assert.Equal(t, BranchOrphaned, branches[normHex(rootC.String())])
+
+	// The shared pre-state is deduplicated: exactly one object under states.
+	states := 0
+
+	for path := range e.corpusFiles() {
+		if strings.HasPrefix(path, corpusStatePrefix) {
+			states++
+		}
+	}
+
+	assert.Equal(t, 1, states)
+}
+
+// Re-processing the retained window after a restart produces zero new objects
+// and rewrites nothing.
+func TestIdempotency(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+
+	e.seedChain(gvr, 160, 163, 166)
+	e.seedHeadAnchor(224)
+
+	e.promoter.tick(t.Context())
+
+	before := e.corpusFiles()
+	require.NotEmpty(t, before)
+
+	// Restart: no persistent cursor, full rescan of the retained window.
+	e.restart()
+	e.promoter.tick(t.Context())
+
+	assert.Equal(t, before, e.corpusFiles())
+}
+
+// The rate cap skips (never queues, never deletes); reorg promotions bypass
+// it; a rescan does not burn budget on already-promoted captures.
+func TestRateCap(t *testing.T) {
+	e := newEnv(t, func(c *Config) { c.RateCapPerHour = 1 })
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	// Two gap-triggered candidates (163, 166) but budget for one.
+	e.seedChain(gvr, 160, 163, 166)
+
+	// A reorg at 167 with a child at 168 extending branch A.
+	rootA, rootB := slotRoot(0xe1, 167), slotRoot(0xe2, 167)
+	e.seedBlock(testNode, 167, 5, rootA, testBlock(t, 167, blockRootFor(166), slotRoot(0xb1, 167), nil), now.Add(time.Second))
+	e.seedBlock("cl-2-test", 167, 5, rootB, testBlock(t, 167, blockRootFor(166), slotRoot(0xb2, 167), nil), now)
+	e.seedBlock(testNode, 168, 5, blockRootFor(168), testBlock(t, 168, rootA, stateRootFor(168), nil), now)
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	slots := map[uint64]int{}
+	for _, path := range e.findManifests() {
+		slots[e.readManifest(path).Block.Slot]++
+	}
+
+	// 163 consumed the budget, 166 was skipped, both reorg branches bypassed.
+	assert.Equal(t, map[uint64]int{163: 1, 167: 2}, slots)
+
+	// The rate window is in-memory by design, so a restart grants fresh
+	// budget. On rescan, 163 and both 167 branches are detected as already
+	// promoted WITHOUT consuming it - which is exactly why the previously
+	// capped 166 now gets through.
+	e.restart()
+	e.promoter.tick(t.Context())
+
+	slots = map[uint64]int{}
+	for _, path := range e.findManifests() {
+		slots[e.readManifest(path).Block.Slot]++
+	}
+
+	assert.Equal(t, map[uint64]int{163: 1, 166: 1, 167: 2}, slots)
+}
+
+// After a restart-rescan, cap budget is NOT spent on captures that already
+// exist in the corpus: a new trigger arriving right after a rescan is still
+// admitted.
+func TestRescanDoesNotBurnRateBudget(t *testing.T) {
+	e := newEnv(t, func(c *Config) { c.RateCapPerHour = 1 })
+	gvr := fillRoot(0x11)
+
+	e.seedChain(gvr, 160, 163)
+	e.seedHeadAnchor(224)
+
+	e.promoter.tick(t.Context())
+	require.Len(t, e.findManifests(), 1)
+
+	// Restart, rescan (finds 163 already promoted), then a fresh trigger in
+	// epoch 6 becomes visible.
+	e.restart()
+	e.promoter.tick(t.Context())
+
+	e.seedChain(gvr, 192, 195) // epoch 6, gap at 195
+	e.seedHeadAnchor(256)      // epoch 8 -> target 6
+	e.promoter.tick(t.Context())
+
+	slots := map[uint64]bool{}
+	for _, path := range e.findManifests() {
+		slots[e.readManifest(path).Block.Slot] = true
+	}
+
+	assert.True(t, slots[195], "fresh trigger after rescan must still have budget")
+}
+
+// An undecodable block (fork newer than the pinned library) is itself a
+// trigger and is promoted with decoded=false, pair_verified=false.
+func TestUndecodableForkPromoted(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	e.seedChain(gvr, 162)
+
+	raw := undecodableBlock(163, blockRootFor(162), slotRoot(0xcc, 163))
+	e.seedBlock(testNode, 163, 5, slotRoot(0xdd, 163), raw, now)
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+
+	m := e.readManifest(manifests[0])
+	assert.Equal(t, []string{TriggerUndecodableFork}, m.Promotion.Triggers)
+	assert.False(t, m.Promotion.Decoded)
+	assert.False(t, m.Promotion.PairVerified)
+	assert.Equal(t, "unknown", m.Fork.Name)
+	assert.Contains(t, manifests[0], "/unknown/")
+
+	// Pairing still resolved via byte-peeks; the claim is present but
+	// unproven, and the block bytes are stored byte-identically.
+	require.NotNil(t, m.Prestate)
+	assert.Equal(t, uint64(162), m.Prestate.Slot)
+	assert.Equal(t, normHex(stateRootFor(162).String()), m.Prestate.ExpectedStateRoot)
+
+	blockPath := strings.TrimSuffix(manifests[0], captureManifestName) + captureBlockName
+	assert.Equal(t, raw, e.readCorpusObject(blockPath))
+}
+
+// A missing parent state degrades to an unpaired block promotion - an
+// unpaired real block still beats nothing.
+func TestMissingParentStatePromotesUnpaired(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	// Parent block at 160 but NO state at 160 (agent hole).
+	e.seedBlock(testNode, 160, 5, blockRootFor(160), testBlock(t, 160, blockRootFor(159), stateRootFor(160), nil), now)
+	e.seedBlock(testNode, 163, 5, blockRootFor(163), testBlock(t, 163, blockRootFor(160), stateRootFor(163), nil), now)
+
+	// A state elsewhere lets the network GVR resolve.
+	e.seedState(testNode, 163, stateRootFor(163), testState(gvr, 163), now)
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+
+	m := e.readManifest(manifests[0])
+	assert.Equal(t, uint64(163), m.Block.Slot)
+	assert.Nil(t, m.Prestate)
+	assert.False(t, m.Promotion.PairVerified)
+	assert.Equal(t, testNetwork+"-11111111", m.Network.Name)
+
+	for path := range e.corpusFiles() {
+		assert.False(t, strings.HasPrefix(path, corpusStatePrefix), "no state objects expected, found %s", path)
+	}
+}
+
+// A state whose GVR contradicts the network is never promoted under it:
+// label integrity beats promote-freely.
+func TestGVRMismatchStateNotPromoted(t *testing.T) {
+	e := newEnv(t, nil)
+	goodGvr, badGvr := fillRoot(0x11), fillRoot(0x22)
+	now := time.Now()
+
+	// The parent row exists but its object is gone, so the pairing claim
+	// cannot be branch-verified and falls back to slot-level matching.
+	e.insertBlockRow(testNode, 160, 5, blockRootFor(160).String(), "missing/location", now)
+	e.seedBlock(testNode, 163, 5, blockRootFor(163), testBlock(t, 163, blockRootFor(160), stateRootFor(163), nil), now)
+
+	// The state at the parent slot belongs to another chain (recreated
+	// devnet with the same name); a newer state carries the real GVR.
+	e.seedState(testNode, 160, stateRootFor(160), testState(badGvr, 160), now.Add(-time.Hour))
+	e.seedState(testNode, 163, stateRootFor(163), testState(goodGvr, 163), now)
+
+	e.seedHeadAnchor(224)
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+
+	m := e.readManifest(manifests[0])
+	assert.Equal(t, uint64(163), m.Block.Slot)
+	assert.Nil(t, m.Prestate, "mismatched state must not be paired")
+	assert.Equal(t, testNetwork+"-11111111", m.Network.Name)
+	assert.Equal(t, normHex(goodGvr.String()), m.Network.GenesisValidatorsRoot)
+
+	badSha := sha256Hex(testState(badGvr, 160))
+	_, exists := e.corpusFiles()[statePath(badSha)]
+	assert.False(t, exists, "mismatched state must not reach the corpus")
+}
+
+// Baseline fires on epoch%N == 0 for the first qualifying slot only, so
+// re-processing selects the same slots.
+func TestBaselineTrigger(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+
+	e.seedChain(gvr, 256, 257) // epoch 8, 8%8 == 0
+	e.seedHeadAnchor(320)      // epoch 10 -> target 8
+
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+
+	m := e.readManifest(manifests[0])
+	assert.Equal(t, uint64(256), m.Block.Slot)
+	assert.Equal(t, []string{TriggerBaseline}, m.Promotion.Triggers)
+}
+
+func TestSlashingTrigger(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	e.seedChain(gvr, 160)
+	e.seedBlock(testNode, 161, 5, blockRootFor(161), testBlock(t, 161, blockRootFor(160), stateRootFor(161), withAttesterSlashing), now)
+	e.seedHeadAnchor(224)
+
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+
+	m := e.readManifest(manifests[0])
+	assert.Equal(t, uint64(161), m.Block.Slot)
+	assert.Equal(t, []string{TriggerSlashing}, m.Promotion.Triggers)
+	assert.True(t, m.Promotion.PairVerified)
+}
+
+func TestLowParticipationTrigger(t *testing.T) {
+	e := newEnv(t, nil)
+	gvr := fillRoot(0x11)
+	now := time.Now()
+
+	e.seedChain(gvr, 160)
+	e.seedBlock(testNode, 161, 5, blockRootFor(161), testBlock(t, 161, blockRootFor(160), stateRootFor(161), withSparseSyncBits), now)
+	e.seedHeadAnchor(224)
+
+	e.promoter.tick(t.Context())
+
+	manifests := e.findManifests()
+	require.Len(t, manifests, 1)
+
+	m := e.readManifest(manifests[0])
+	assert.Equal(t, uint64(161), m.Block.Slot)
+	assert.Equal(t, []string{TriggerLowParticipation}, m.Promotion.Triggers)
+}
+
+// Disabled triggers do not fire.
+func TestTriggerToggle(t *testing.T) {
+	disabled := false
+	e := newEnv(t, func(c *Config) { c.Triggers.Gap = &disabled })
+	gvr := fillRoot(0x11)
+
+	e.seedChain(gvr, 160, 163)
+	e.seedHeadAnchor(224)
+
+	e.promoter.tick(t.Context())
+
+	assert.Empty(t, e.findManifests())
+}
+
+func TestCaptureID(t *testing.T) {
+	id := captureID(384, "0xdeadbeefcafebabe0000000000000000000000000000000000000000000000ff")
+	assert.Equal(t, "000000384-deadbeefcafe", id)
+
+	// Lexical order equals slot order.
+	assert.Less(t, captureID(99, "0xaa"), captureID(100, "0xaa"))
+}
+
+func TestNetworkID(t *testing.T) {
+	assert.Equal(t, fmt.Sprintf("%s-2093236b", testNetwork), networkID(testNetwork, "0x2093236b11223344"))
+}

--- a/pkg/server/service/promotion/promotion_test.go
+++ b/pkg/server/service/promotion/promotion_test.go
@@ -1,6 +1,7 @@
 package promotion
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -631,6 +632,53 @@ func TestReorgCapCeiling(t *testing.T) {
 	e.promoter.tick(t.Context())
 
 	assert.Len(t, e.findManifests(), 2)
+}
+
+// Stop must return whether or not the run loop was ever started: it also runs
+// when Start failed on an unreachable corpus store, or when an earlier
+// service failed first, and the context it is handed is the process context,
+// which shutdown does not cancel. Waiting on something only a running loop
+// can satisfy would hang the process past its own signal handler.
+func TestStopWithoutStartDoesNotHang(t *testing.T) {
+	e := newEnv(t, nil)
+
+	done := make(chan error, 1)
+
+	go func() { done <- e.promoter.Stop(context.Background()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop hung with no run loop to wait for")
+	}
+
+	// Stopping twice must not panic on a re-closed channel.
+	require.NoError(t, e.promoter.Stop(context.Background()))
+}
+
+// Stop waits for an in-flight tick, then returns.
+func TestStopWaitsForRunningLoop(t *testing.T) {
+	e := newEnv(t, nil)
+
+	e.seedChain(fillRoot(0x11), 160, 163)
+	e.seedHeadAnchor(224)
+
+	require.NoError(t, e.promoter.Start(t.Context(), nil))
+
+	done := make(chan error, 1)
+
+	go func() { done <- e.promoter.Stop(context.Background()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(stopTimeout + 5*time.Second):
+		t.Fatal("Stop outlived its own timeout")
+	}
+
+	// The first tick ran to completion before Stop returned.
+	assert.Len(t, e.findManifests(), 1)
 }
 
 func TestCaptureID(t *testing.T) {

--- a/pkg/server/service/promotion/ssz.go
+++ b/pkg/server/service/promotion/ssz.go
@@ -1,0 +1,141 @@
+package promotion
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// Fork-stable byte offsets into raw SSZ. They allow extraction without typed
+// decoding, which keeps pairing working on forks the pinned go-eth2-client
+// cannot decode yet. Stable phase0 through gloas; re-verify per new fork.
+const (
+	// SignedBeaconBlock: a 4-byte offset to the variable `message` followed
+	// by the fixed 96-byte signature, so the leading offset must equal 100.
+	blockMessageOffset    = 100
+	blockSlotOffset       = 100
+	blockParentRootOffset = 116
+	blockStateRootOffset  = 148
+	blockMinLen           = blockStateRootOffset + rootLen
+
+	// BeaconState fixed prefix, identical in all forks.
+	stateGVROffset  = 8
+	stateSlotOffset = 40
+	stateMinLen     = stateSlotOffset + 8
+
+	rootLen = 32
+)
+
+var (
+	errBlockMalformed  = errors.New("signed beacon block bytes are truncated or misfiled (leading offset != 100)")
+	errStateMalformed  = errors.New("beacon state bytes are shorter than the fixed prefix")
+	errUndecodableFork = errors.New("no supported fork decodes this block")
+)
+
+// blockPeek is the fork-stable view of a SignedBeaconBlock's raw SSZ.
+type blockPeek struct {
+	Slot       uint64
+	ParentRoot phase0.Root
+	StateRoot  phase0.Root
+}
+
+// peekBlock extracts the fork-stable fields of a SignedBeaconBlock. A payload
+// failing the sanity rules is truncated or misfiled; promote nothing under a
+// label it contradicts.
+func peekBlock(raw []byte) (*blockPeek, error) {
+	if len(raw) < blockMinLen {
+		return nil, errBlockMalformed
+	}
+
+	if binary.LittleEndian.Uint32(raw[0:4]) != blockMessageOffset {
+		return nil, errBlockMalformed
+	}
+
+	p := &blockPeek{
+		Slot: binary.LittleEndian.Uint64(raw[blockSlotOffset : blockSlotOffset+8]),
+	}
+
+	copy(p.ParentRoot[:], raw[blockParentRootOffset:blockParentRootOffset+rootLen])
+	copy(p.StateRoot[:], raw[blockStateRootOffset:blockStateRootOffset+rootLen])
+
+	return p, nil
+}
+
+// statePeek is the fork-stable view of a BeaconState's raw SSZ prefix.
+type statePeek struct {
+	GenesisValidatorsRoot phase0.Root
+	Slot                  uint64
+}
+
+func peekState(raw []byte) (*statePeek, error) {
+	if len(raw) < stateMinLen {
+		return nil, errStateMalformed
+	}
+
+	p := &statePeek{
+		Slot: binary.LittleEndian.Uint64(raw[stateSlotOffset : stateSlotOffset+8]),
+	}
+
+	copy(p.GenesisValidatorsRoot[:], raw[stateGVROffset:stateGVROffset+rootLen])
+
+	return p, nil
+}
+
+type sszBlock interface {
+	UnmarshalSSZ([]byte) error
+	MarshalSSZ() ([]byte, error)
+}
+
+// roundTrips reports whether raw decodes into b AND re-encodes to the exact
+// same bytes. SSZ offsets make wrong-fork decodes overwhelmingly fail; the
+// byte-identical round-trip closes the rest.
+func roundTrips(b sszBlock, raw []byte) bool {
+	if err := b.UnmarshalSSZ(raw); err != nil {
+		return false
+	}
+
+	enc, err := b.MarshalSSZ()
+
+	return err == nil && bytes.Equal(enc, raw)
+}
+
+// decodeBlock attempts a typed decode of raw SignedBeaconBlock SSZ, trying
+// forks newest first. A fork too new for the pinned go-eth2-client returns
+// errUndecodableFork - which is itself a trigger, never a hard failure.
+// Structurally identical forks report the older name (e.g. fulu blocks decode
+// as electra); triggers evaluate identically either way.
+func decodeBlock(raw []byte) (*spec.VersionedSignedBeaconBlock, error) {
+	if b := new(electra.SignedBeaconBlock); roundTrips(b, raw) {
+		return &spec.VersionedSignedBeaconBlock{Version: spec.DataVersionElectra, Electra: b}, nil
+	}
+
+	if b := new(deneb.SignedBeaconBlock); roundTrips(b, raw) {
+		return &spec.VersionedSignedBeaconBlock{Version: spec.DataVersionDeneb, Deneb: b}, nil
+	}
+
+	if b := new(capella.SignedBeaconBlock); roundTrips(b, raw) {
+		return &spec.VersionedSignedBeaconBlock{Version: spec.DataVersionCapella, Capella: b}, nil
+	}
+
+	if b := new(bellatrix.SignedBeaconBlock); roundTrips(b, raw) {
+		return &spec.VersionedSignedBeaconBlock{Version: spec.DataVersionBellatrix, Bellatrix: b}, nil
+	}
+
+	if b := new(altair.SignedBeaconBlock); roundTrips(b, raw) {
+		return &spec.VersionedSignedBeaconBlock{Version: spec.DataVersionAltair, Altair: b}, nil
+	}
+
+	if b := new(phase0.SignedBeaconBlock); roundTrips(b, raw) {
+		return &spec.VersionedSignedBeaconBlock{Version: spec.DataVersionPhase0, Phase0: b}, nil
+	}
+
+	return nil, errUndecodableFork
+}

--- a/pkg/server/service/promotion/ssz_test.go
+++ b/pkg/server/service/promotion/ssz_test.go
@@ -1,0 +1,92 @@
+package promotion
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeekBlock(t *testing.T) {
+	parent := fillRoot(0x0a)
+	state := fillRoot(0x0b)
+	raw := testBlock(t, 12345, parent, state, nil)
+
+	peek, err := peekBlock(raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(12345), peek.Slot)
+	assert.Equal(t, parent, peek.ParentRoot)
+	assert.Equal(t, state, peek.StateRoot)
+}
+
+func TestPeekBlockRejectsTruncated(t *testing.T) {
+	raw := testBlock(t, 1, fillRoot(0x0a), fillRoot(0x0b), nil)
+
+	_, err := peekBlock(raw[:100])
+	assert.ErrorIs(t, err, errBlockMalformed)
+}
+
+func TestPeekBlockRejectsBadOffset(t *testing.T) {
+	raw := testBlock(t, 1, fillRoot(0x0a), fillRoot(0x0b), nil)
+	corrupted := append([]byte{}, raw...)
+	binary.LittleEndian.PutUint32(corrupted[0:4], 96)
+
+	_, err := peekBlock(corrupted)
+	assert.ErrorIs(t, err, errBlockMalformed)
+}
+
+func TestPeekState(t *testing.T) {
+	gvr := fillRoot(0x1c)
+	raw := testState(gvr, 777)
+
+	peek, err := peekState(raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(777), peek.Slot)
+	assert.Equal(t, gvr, peek.GenesisValidatorsRoot)
+
+	_, err = peekState(raw[:40])
+	assert.ErrorIs(t, err, errStateMalformed)
+}
+
+func TestDecodeBlock(t *testing.T) {
+	raw := testBlock(t, 42, fillRoot(0x0a), fillRoot(0x0b), nil)
+
+	decoded, err := decodeBlock(raw)
+	require.NoError(t, err)
+	assert.Equal(t, spec.DataVersionAltair, decoded.Version)
+
+	slot, err := decoded.Slot()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), uint64(slot))
+}
+
+// undecodableBlock builds bytes that pass the fork-stable sanity rules but
+// decode under no supported fork - the shape of a brand-new fork.
+func undecodableBlock(slot uint64, parentRoot, stateRoot [32]byte) []byte {
+	raw := make([]byte, 220)
+	binary.LittleEndian.PutUint32(raw[0:4], blockMessageOffset)
+	binary.LittleEndian.PutUint64(raw[blockSlotOffset:blockSlotOffset+8], slot)
+	copy(raw[blockParentRootOffset:], parentRoot[:])
+	copy(raw[blockStateRootOffset:], stateRoot[:])
+
+	for i := blockMinLen; i < len(raw); i++ {
+		raw[i] = 0xff
+	}
+
+	return raw
+}
+
+func TestDecodeBlockUndecodableFork(t *testing.T) {
+	raw := undecodableBlock(99, fillRoot(0x0a), fillRoot(0x0b))
+
+	peek, err := peekBlock(raw)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(99), peek.Slot)
+
+	_, err = decodeBlock(raw)
+	assert.ErrorIs(t, err, errUndecodableFork)
+}

--- a/pkg/server/service/promotion/triggers.go
+++ b/pkg/server/service/promotion/triggers.go
@@ -1,0 +1,77 @@
+package promotion
+
+import "github.com/attestantio/go-eth2-client/spec"
+
+// Trigger names recorded in manifests. Selection may be sloppy-generous;
+// these labels may not be, so a trigger is only ever recorded when its
+// condition was positively observed.
+const (
+	TriggerSlashing             = "slashing"
+	TriggerVoluntaryExit        = "voluntary_exit"
+	TriggerBLSToExecutionChange = "bls_to_execution_change"
+	TriggerDeposit              = "deposit"
+	TriggerExecutionRequest     = "execution_request"
+	TriggerGap                  = "gap"
+	TriggerReorg                = "reorg"
+	TriggerLowParticipation     = "low_participation"
+	TriggerForkBoundary         = "fork_boundary"
+	TriggerUndecodableFork      = "undecodable_fork"
+	TriggerBaseline             = "baseline"
+)
+
+// decodedTriggers evaluates the triggers that need a typed decode. Accessor
+// errors mean the field does not exist on this fork (or the library does not
+// know where it lives); an unknown location degrades to fewer triggers, never
+// to an error.
+func (p *Promoter) decodedTriggers(block *spec.VersionedSignedBeaconBlock) []string {
+	triggers := make([]string, 0, 4)
+	cfg := &p.config.Triggers
+
+	if triggerEnabled(cfg.Slashing) {
+		attester, _ := block.AttesterSlashings()
+		proposer, _ := block.ProposerSlashings()
+
+		if len(attester) > 0 || len(proposer) > 0 {
+			triggers = append(triggers, TriggerSlashing)
+		}
+	}
+
+	if triggerEnabled(cfg.VoluntaryExit) {
+		if exits, err := block.VoluntaryExits(); err == nil && len(exits) > 0 {
+			triggers = append(triggers, TriggerVoluntaryExit)
+		}
+	}
+
+	if triggerEnabled(cfg.BLSToExecutionChange) {
+		if changes, err := block.BLSToExecutionChanges(); err == nil && len(changes) > 0 {
+			triggers = append(triggers, TriggerBLSToExecutionChange)
+		}
+	}
+
+	if triggerEnabled(cfg.Deposit) {
+		if deposits, err := block.Deposits(); err == nil && len(deposits) > 0 {
+			triggers = append(triggers, TriggerDeposit)
+		}
+	}
+
+	if triggerEnabled(cfg.ExecutionRequest) {
+		if requests, err := block.ExecutionRequests(); err == nil && requests != nil {
+			if len(requests.Deposits)+len(requests.Withdrawals)+len(requests.Consolidations) > 0 {
+				triggers = append(triggers, TriggerExecutionRequest)
+			}
+		}
+	}
+
+	if triggerEnabled(cfg.LowParticipation) {
+		if aggregate, err := block.SyncAggregate(); err == nil && aggregate != nil {
+			bits := aggregate.SyncCommitteeBits
+			if total := bits.Len(); total > 0 {
+				if float64(bits.Count())/float64(total) < p.config.SyncParticipationFloor {
+					triggers = append(triggers, TriggerLowParticipation)
+				}
+			}
+		}
+	}
+
+	return triggers
+}

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -30,7 +30,7 @@ const (
 	ServiceTypePromotion Type = promotion.ServiceType
 )
 
-func CreateGRPCServices(ctx context.Context, log logrus.FieldLogger, cfg *Config, p *persistence.Indexer, c store.Store, grpcConn string, grpcOpts []grpc.DialOption, ethConfig *ethereum.Config) ([]GRPCService, error) {
+func CreateGRPCServices(ctx context.Context, log logrus.FieldLogger, cfg *Config, p *persistence.Indexer, c store.Store, bufferStore store.Config, grpcConn string, grpcOpts []grpc.DialOption, ethConfig *ethereum.Config) ([]GRPCService, error) {
 	services := []GRPCService{}
 
 	// Indexer
@@ -72,6 +72,12 @@ func CreateGRPCServices(ctx context.Context, log logrus.FieldLogger, cfg *Config
 		}
 
 		if err := cfg.Promotion.ValidateRetention(retention); err != nil {
+			return nil, err
+		}
+
+		// The corpus outlives every devnet; the buffer is reaped. They must
+		// not be the same destination.
+		if err := cfg.Promotion.ValidateDistinctFrom(bufferStore); err != nil {
 			return nil, err
 		}
 

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethpandaops/tracoor/pkg/server/persistence"
 	"github.com/ethpandaops/tracoor/pkg/server/service/api"
 	"github.com/ethpandaops/tracoor/pkg/server/service/indexer"
+	"github.com/ethpandaops/tracoor/pkg/server/service/promotion"
 	"github.com/ethpandaops/tracoor/pkg/store"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -23,9 +24,10 @@ type GRPCService interface {
 type Type string
 
 const (
-	ServiceTypeUnknown Type = "unknown"
-	ServiceTypeIndexer Type = indexer.ServiceType
-	ServiceTypeAPI     Type = api.ServiceType
+	ServiceTypeUnknown   Type = "unknown"
+	ServiceTypeIndexer   Type = indexer.ServiceType
+	ServiceTypeAPI       Type = api.ServiceType
+	ServiceTypePromotion Type = promotion.ServiceType
 )
 
 func CreateGRPCServices(ctx context.Context, log logrus.FieldLogger, cfg *Config, p *persistence.Indexer, c store.Store, grpcConn string, grpcOpts []grpc.DialOption, ethConfig *ethereum.Config) ([]GRPCService, error) {
@@ -54,6 +56,32 @@ func CreateGRPCServices(ctx context.Context, log logrus.FieldLogger, cfg *Config
 	}
 
 	services = append(services, ap)
+
+	// Promotion (opt-in)
+	if err := defaults.Set(&cfg.Promotion); err != nil {
+		return nil, err
+	}
+
+	if cfg.Promotion.Enabled {
+		// Refuse to start when the buffer cannot outlive the processing
+		// lag: the promotion service reads lagged slots from a buffer the
+		// retention reaper empties on its own schedule.
+		retention := cfg.Indexer.Retention.BeaconStates.Duration
+		if cfg.Indexer.Retention.BeaconBlocks.Duration < retention {
+			retention = cfg.Indexer.Retention.BeaconBlocks.Duration
+		}
+
+		if err := cfg.Promotion.ValidateRetention(retention); err != nil {
+			return nil, err
+		}
+
+		prom, err := promotion.NewPromoter(ctx, log, &cfg.Promotion, p, c)
+		if err != nil {
+			return nil, err
+		}
+
+		services = append(services, prom)
+	}
 
 	return services, nil
 }

--- a/pkg/store/fs.go
+++ b/pkg/store/fs.go
@@ -100,6 +100,17 @@ func (s *FSStore) removeFile(path string) error {
 	return os.Remove(path)
 }
 
+func (s *FSStore) SaveRaw(ctx context.Context, params *SaveParams) (string, error) {
+	parts := strings.Split(params.Location, "/")
+
+	path := filepath.Join(s.basePath, filepath.Join(parts...))
+	if err := s.saveFile(params.Data, path); err != nil {
+		return "", err
+	}
+
+	return params.Location, nil
+}
+
 func (s *FSStore) SaveBeaconState(ctx context.Context, params *SaveParams) (string, error) {
 	parts := strings.Split(params.Location, "/")
 
@@ -328,7 +339,7 @@ func (s *FSStore) Copy(ctx context.Context, params *CopyParams) error {
 	}
 
 	// Write to the destination file
-	if err := os.WriteFile(destination, data, 0o600); err != nil { //nolint:gosec // path is constructed from validated basePath
+	if err := os.WriteFile(destination, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write destination file: %w", err)
 	}
 

--- a/pkg/store/fs.go
+++ b/pkg/store/fs.go
@@ -339,7 +339,7 @@ func (s *FSStore) Copy(ctx context.Context, params *CopyParams) error {
 	}
 
 	// Write to the destination file
-	if err := os.WriteFile(destination, data, 0o600); err != nil {
+	if err := os.WriteFile(destination, data, 0o600); err != nil { //nolint:gosec // path is constructed from validated basePath
 		return fmt.Errorf("failed to write destination file: %w", err)
 	}
 

--- a/pkg/store/metrics.go
+++ b/pkg/store/metrics.go
@@ -21,79 +21,92 @@ type BasicMetrics struct {
 	cacheMiss *prometheus.CounterVec
 }
 
+// instances is one BasicMetrics per namespace. A process can run more than
+// one store - the capture buffer and the promotion corpus, for instance - and
+// a single global instance would silently attribute every store's activity to
+// whichever one was constructed first.
 var (
-	instance *BasicMetrics
-	once     sync.Once
+	instances = map[string]*BasicMetrics{}
+	mu        sync.Mutex
 )
 
 func GetBasicMetricsInstance(namespace, storeType string, enabled bool) *BasicMetrics {
-	once.Do(func() {
-		instance = &BasicMetrics{
-			namespace: namespace,
+	mu.Lock()
+	defer mu.Unlock()
 
-			info: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "info",
-				Help:      "Information about the implementation of the store",
-			}, []string{"implementation"}),
+	if existing, ok := instances[namespace]; ok {
+		existing.info.WithLabelValues(storeType).Set(1)
 
-			itemsAdded: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "items_added_count",
-				Help:      "Number of items added to the store",
-			}, []string{labelType}),
-			itemsRemoved: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "items_removed_count",
-				Help:      "Number of items removed from the store",
-			}, []string{labelType}),
-			itemsRetreived: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "items_retrieved_count",
-				Help:      "Number of items retreived from the store",
-			}, []string{labelType}),
-			itemsStored: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Namespace: namespace,
-				Name:      "items_stored_total",
-				Help:      "Number of items stored in the store",
-			}, []string{labelType}),
-			itemsUrlsRetreived: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "items_urls_retrieved_count",
-				Help:      "Number of items URLs retreived",
-			}, []string{labelType}),
-			cacheHit: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "cache_hit_count",
-				Help:      "Number of cache hits",
-			}, []string{labelType}),
-			cacheMiss: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: namespace,
-				Name:      "cache_miss_count",
-				Help:      "Number of cache misses",
-			}, []string{labelType}),
-			itemsAddedBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: namespace,
-				Name:      "items_added_bytes",
-				Help:      "Size of items added to the store",
-				Buckets:   prometheus.ExponentialBuckets(1024000, 2, 13),
-			}, []string{labelType}),
-		}
+		return existing
+	}
 
-		if enabled {
-			prometheus.MustRegister(instance.info)
-			prometheus.MustRegister(instance.itemsAdded)
-			prometheus.MustRegister(instance.itemsAddedBytes)
-			prometheus.MustRegister(instance.itemsRemoved)
-			prometheus.MustRegister(instance.itemsRetreived)
-			prometheus.MustRegister(instance.itemsUrlsRetreived)
-			prometheus.MustRegister(instance.itemsStored)
-			prometheus.MustRegister(instance.cacheHit)
-			prometheus.MustRegister(instance.cacheMiss)
-		}
+	instance := &BasicMetrics{
+		namespace: namespace,
 
-		instance.info.WithLabelValues(storeType).Set(1)
-	})
+		info: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "info",
+			Help:      "Information about the implementation of the store",
+		}, []string{"implementation"}),
+
+		itemsAdded: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "items_added_count",
+			Help:      "Number of items added to the store",
+		}, []string{labelType}),
+		itemsRemoved: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "items_removed_count",
+			Help:      "Number of items removed from the store",
+		}, []string{labelType}),
+		itemsRetreived: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "items_retrieved_count",
+			Help:      "Number of items retreived from the store",
+		}, []string{labelType}),
+		itemsStored: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "items_stored_total",
+			Help:      "Number of items stored in the store",
+		}, []string{labelType}),
+		itemsUrlsRetreived: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "items_urls_retrieved_count",
+			Help:      "Number of items URLs retreived",
+		}, []string{labelType}),
+		cacheHit: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "cache_hit_count",
+			Help:      "Number of cache hits",
+		}, []string{labelType}),
+		cacheMiss: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "cache_miss_count",
+			Help:      "Number of cache misses",
+		}, []string{labelType}),
+		itemsAddedBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "items_added_bytes",
+			Help:      "Size of items added to the store",
+			Buckets:   prometheus.ExponentialBuckets(1024000, 2, 13),
+		}, []string{labelType}),
+	}
+
+	if enabled {
+		prometheus.MustRegister(instance.info)
+		prometheus.MustRegister(instance.itemsAdded)
+		prometheus.MustRegister(instance.itemsAddedBytes)
+		prometheus.MustRegister(instance.itemsRemoved)
+		prometheus.MustRegister(instance.itemsRetreived)
+		prometheus.MustRegister(instance.itemsUrlsRetreived)
+		prometheus.MustRegister(instance.itemsStored)
+		prometheus.MustRegister(instance.cacheHit)
+		prometheus.MustRegister(instance.cacheMiss)
+	}
+
+	instance.info.WithLabelValues(storeType).Set(1)
+
+	instances[namespace] = instance
 
 	return instance
 }

--- a/pkg/store/metrics.go
+++ b/pkg/store/metrics.go
@@ -9,6 +9,11 @@ import (
 type BasicMetrics struct {
 	namespace string
 
+	// registered records whether the collectors reached the prometheus
+	// registry, so a namespace first created with metrics disabled can
+	// still be registered later by a store that wants them.
+	registered bool
+
 	info               *prometheus.GaugeVec
 	itemsAdded         *prometheus.CounterVec
 	itemsAddedBytes    *prometheus.HistogramVec
@@ -35,6 +40,9 @@ func GetBasicMetricsInstance(namespace, storeType string, enabled bool) *BasicMe
 	defer mu.Unlock()
 
 	if existing, ok := instances[namespace]; ok {
+		// A namespace whose first store disabled metrics would otherwise
+		// stay unexported for every later store that wants them.
+		existing.register(enabled)
 		existing.info.WithLabelValues(storeType).Set(1)
 
 		return existing
@@ -92,23 +100,31 @@ func GetBasicMetricsInstance(namespace, storeType string, enabled bool) *BasicMe
 		}, []string{labelType}),
 	}
 
-	if enabled {
-		prometheus.MustRegister(instance.info)
-		prometheus.MustRegister(instance.itemsAdded)
-		prometheus.MustRegister(instance.itemsAddedBytes)
-		prometheus.MustRegister(instance.itemsRemoved)
-		prometheus.MustRegister(instance.itemsRetreived)
-		prometheus.MustRegister(instance.itemsUrlsRetreived)
-		prometheus.MustRegister(instance.itemsStored)
-		prometheus.MustRegister(instance.cacheHit)
-		prometheus.MustRegister(instance.cacheMiss)
-	}
-
+	instance.register(enabled)
 	instance.info.WithLabelValues(storeType).Set(1)
 
 	instances[namespace] = instance
 
 	return instance
+}
+
+// register exports the collectors, at most once. Callers hold mu.
+func (m *BasicMetrics) register(enabled bool) {
+	if !enabled || m.registered {
+		return
+	}
+
+	prometheus.MustRegister(m.info)
+	prometheus.MustRegister(m.itemsAdded)
+	prometheus.MustRegister(m.itemsAddedBytes)
+	prometheus.MustRegister(m.itemsRemoved)
+	prometheus.MustRegister(m.itemsRetreived)
+	prometheus.MustRegister(m.itemsUrlsRetreived)
+	prometheus.MustRegister(m.itemsStored)
+	prometheus.MustRegister(m.cacheHit)
+	prometheus.MustRegister(m.cacheMiss)
+
+	m.registered = true
 }
 
 func (m *BasicMetrics) ObserveItemAdded(itemType string) {

--- a/pkg/store/metrics_test.go
+++ b/pkg/store/metrics_test.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// One instance per namespace: a process runs both the capture buffer and the
+// promotion corpus, and a single global instance attributed every store's
+// activity to whichever one was constructed first.
+func TestBasicMetricsAreNamespaced(t *testing.T) {
+	buffer := GetBasicMetricsInstance("test_namespaced_buffer", string(FSStoreType), false)
+	corpus := GetBasicMetricsInstance("test_namespaced_corpus", string(FSStoreType), false)
+
+	assert.NotSame(t, buffer, corpus)
+	assert.Same(t, buffer, GetBasicMetricsInstance("test_namespaced_buffer", string(FSStoreType), false))
+}
+
+// A namespace first created with metrics disabled must still be exported when
+// a later store on the same namespace wants them.
+func TestBasicMetricsRegisterOnUpgrade(t *testing.T) {
+	const namespace = "test_upgrade"
+
+	disabled := GetBasicMetricsInstance(namespace, string(FSStoreType), false)
+	assert.False(t, disabled.registered)
+
+	enabled := GetBasicMetricsInstance(namespace, string(FSStoreType), true)
+	assert.Same(t, disabled, enabled)
+	assert.True(t, enabled.registered)
+
+	// Registering is idempotent: a third store must not panic on a
+	// duplicate collector.
+	assert.NotPanics(t, func() { GetBasicMetricsInstance(namespace, string(FSStoreType), true) })
+}

--- a/pkg/store/s3.go
+++ b/pkg/store/s3.go
@@ -119,6 +119,43 @@ func (s *S3Store) GetRaw(ctx context.Context, location string) (*bytes.Buffer, e
 	return &buff, nil
 }
 
+func (s *S3Store) SaveRaw(ctx context.Context, params *SaveParams) (string, error) {
+	if params.Data == nil {
+		return "", errors.New("data is nil")
+	}
+
+	input := &s3.PutObjectInput{
+		Bucket: aws.String(s.config.BucketName),
+		Key:    aws.String(params.Location),
+		Body:   bytes.NewBuffer(*params.Data),
+	}
+
+	if params.ContentEncoding != "" {
+		input.ContentEncoding = aws.String(params.ContentEncoding)
+	}
+
+	_, err := s.s3Client.PutObject(ctx, input, s3.WithAPIOptions(v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware))
+	if err != nil {
+		var apiErr smithy.APIError
+
+		if errors.As(err, &apiErr) {
+			switch apiErr.(type) {
+			case *s3types.NoSuchBucket:
+				return "", errors.New("bucket does not exist: " + apiErr.Error())
+			case *s3types.NotFound:
+				return "", ErrNotFound
+			default:
+				return "", errors.New("failed to save raw object: " + apiErr.Error())
+			}
+		}
+	}
+
+	s.basicMetrics.ObserveItemAdded(string(RawDataType))
+	s.basicMetrics.ObserveItemAddedBytes(string(RawDataType), len(*params.Data))
+
+	return params.Location, err
+}
+
 func (s *S3Store) StorageHandshakeTokenExists(ctx context.Context, node string) (bool, error) {
 	key := fmt.Sprintf("handshake/%s", node)
 

--- a/pkg/store/s3.go
+++ b/pkg/store/s3.go
@@ -134,8 +134,9 @@ func (s *S3Store) SaveRaw(ctx context.Context, params *SaveParams) (string, erro
 		input.ContentEncoding = aws.String(params.ContentEncoding)
 	}
 
-	_, err := s.s3Client.PutObject(ctx, input, s3.WithAPIOptions(v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware))
-	if err != nil {
+	// Unlike the older Save* methods, a failed put returns before the
+	// counters move: an object that was not written is not an object added.
+	if _, err := s.s3Client.PutObject(ctx, input, s3.WithAPIOptions(v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware)); err != nil {
 		var apiErr smithy.APIError
 
 		if errors.As(err, &apiErr) {
@@ -148,12 +149,14 @@ func (s *S3Store) SaveRaw(ctx context.Context, params *SaveParams) (string, erro
 				return "", errors.New("failed to save raw object: " + apiErr.Error())
 			}
 		}
+
+		return "", err
 	}
 
 	s.basicMetrics.ObserveItemAdded(string(RawDataType))
 	s.basicMetrics.ObserveItemAddedBytes(string(RawDataType), len(*params.Data))
 
-	return params.Location, err
+	return params.Location, nil
 }
 
 func (s *S3Store) StorageHandshakeTokenExists(ctx context.Context, node string) (bool, error) {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -35,6 +35,9 @@ type Store interface {
 	// Copy copies a file from one location to another
 	Copy(ctx context.Context, params *CopyParams) error
 
+	// SaveRaw saves arbitrary bytes to the store at the given location
+	SaveRaw(ctx context.Context, params *SaveParams) (string, error)
+
 	// StorageHandshakeTokenExists checks if a storage handshake token exists in the store
 	StorageHandshakeTokenExists(ctx context.Context, node string) (bool, error)
 	// SaveStorageHandshakeToken saves a storage handshake token to the store

--- a/pkg/store/type.go
+++ b/pkg/store/type.go
@@ -33,4 +33,5 @@ const (
 	BeaconBadBlobDataType  DataType = "beacon_bad_blob"
 	BlockTraceDataType     DataType = "execution_block_trace"
 	BadBlockDataType       DataType = "execution_bad_block"
+	RawDataType            DataType = "raw"
 )

--- a/pkg/yaml/raw_config.go
+++ b/pkg/yaml/raw_config.go
@@ -13,3 +13,9 @@ func (r *RawMessage) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (r *RawMessage) Unmarshal(v interface{}) error {
 	return r.unmarshal(v)
 }
+
+// IsZero reports whether the message was never populated, i.e. its key was
+// absent from the document. Unmarshal panics on a zero message.
+func (r *RawMessage) IsZero() bool {
+	return r.unmarshal == nil
+}


### PR DESCRIPTION
## What

A new opt-in, server-side **promotion service** that watches the short-retention capture buffer with hindsight (default 2 epochs behind the freshest indexed epoch) and **copies** interesting consensus captures — as a replayable `(parent post-state, block)` pair plus a `manifest.json` — into a separate, global, **append-only** corpus store that outlives every devnet. Consumers (fuzzers, client teams) pull from that bucket with nothing but an S3 client.

Selection is deliberately sloppy-generous (booleans + rate caps, no scoring); labels are not: every manifest claim is either positively observed or omitted.

```
agents (unchanged) --> buffer bucket + postgres index (unchanged, reaped)
                                 |
                    promotion service (new, server-side)
                    reads DB + store at head - lagEpochs
                                 |
                   append-only global corpus bucket (new, write-only IAM)
```

**No agent changes. No proto changes. No UI.** The service keeps no persistent state: content-addressed states and `(slot, block_root)`-derived capture ids make promotion idempotent, so a restart just rescans the retained window. The only schema change is a new `(network, epoch)` index on `beacon_blocks` / `beacon_states` — see Plumbing.

## Corpus layout (schema v1)

```
v1/states/<sha256-of-raw-ssz>.ssz                        # uncompressed, content-addressed, deduplicated
v1/captures/<network>/<fork>/<capture_id>/input.ssz      # the SignedBeaconBlock, raw
v1/captures/<network>/<fork>/<capture_id>/manifest.json
```

- `network` = `<name>-<genesis_validators_root[2:10]>` — kurtosis devnets all call themselves `testnet` and are recreated constantly; the GVR prefix is the only stable disambiguator. The name is sanitised to a single opaque path segment, in `networkID` itself, so the manifest's `network.name` and the key it lives under can never disagree.
- `capture_id` = `<slot zero-padded to 9>-<block_root hex[0:12]>` — lexical order equals slot order; both branches of a reorg coexist.

## Key invariants implemented

- **Pre-state = post-state of the block's PARENT, resolved by `parent_root`**, never `slot-1` (skipped slots make them differ). The state row is selected branch-exactly by matching the parent block's own `state_root` field.
- **Byte identity**: buffer objects are gunzipped before hashing; corpus objects are the exact raw SSZ the node served, stored uncompressed; `sha256(raw)` is the state's identity.
- **`expected_state_root`** in the manifest is the PARENT block's `state_root` read from the parent's own bytes — so any consumer with an SSZ library can verify `hash_tree_root(state) == expected_state_root` forever, without tracoor. Omitted (never substituted) when the parent block is missing.
- **Copy-only / read-only**: the service never deletes anything anywhere; corpus IAM should be `PutObject`/`GetObject`/`ListBucket` only (`GetObject` or `ListBucket` is required — the idempotency probe uses `HeadObject`). Startup refuses a corpus store that addresses the same destination as the buffer store.
- **Three-tier rate budget**, per network per hour, the only flood guard; skip, never queue, never delete. Already-promoted captures are detected via a cheap existence probe *before* admission, so restart rescans never burn budget, and budget is consumed only once the manifest lands — a corpus outage costs nothing.
- **Retention safety**: server refuses to start when `min(beaconStates, beaconBlocks) retention < (lagEpochs + 1) x slotsPerEpoch x secondsPerSlot`.
- **Reorgs**: `>1` distinct `block_root` at a slot promotes **both branches**; canonicality is resolved by deterministic evidence (which root a later block references as parent, with next-epoch lookahead), falling back to capture recency.
- **Network identity is tracked, not assumed**: a name whose chain loses height, or whose genesis validators root changes, has its cursor and identity rebuilt rather than pinned for the process lifetime. See Devnet recreation.
- **Every unbounded path is bounded**: epochs per tick, epochs per network, promotions per tier, and the shutdown wait all have explicit ceilings.
- **Degradation, never silence**: undecodable fork -> promoted with `undecodable_fork`, `decoded:false`; missing parent state -> block promoted unpaired with `pair_verified:false`; a state whose GVR contradicts the network is never filed under it. All skips are metric-visible.
- **Fork-stable byte peeks** (leading offset == 100, `parent_root`@116, `state_root`@148; state GVR@8..40, slot@40) keep pairing working even on forks the pinned `go-eth2-client` cannot decode. Typed decodes are only accepted when they round-trip byte-identically.

## Triggers (all config-toggleable, default on)

`slashing`, `voluntary_exit`, `bls_to_execution_change`, `deposit`, `execution_request`, `gap` (>= 2 skipped slots), `reorg`, `low_participation` (sync bits < 0.95), `fork_boundary`, `undecodable_fork`, `baseline` (the lowest indexed slot of every 8th epoch — which epochs fire is a pure function of the epoch number, which slot fires is a pure function of the index, so rescans pick the same captures).

## Admission: three tiers

A single budget was tested to be the wrong shape. Under sustained non-finality `low_participation` fires on every block, and the flood starves exactly the rarest captures — a slashing landing mid-stall could be rate-capped away, permanently, once the reaper empties the buffer.

| tier | triggers | default cap/hour |
| --- | --- | --- |
| common | `gap`, `low_participation`, `baseline`, `undecodable_fork`, `deposit`, `execution_request` | `rateCapPerHour` 30 |
| rare | `slashing`, `voluntary_exit`, `bls_to_execution_change`, `fork_boundary` | `rareCapPerHour` 120 |
| reorg | `reorg` | `reorgCapPerHour` 1000 |

Rare never competes with a flood but still meets a hard ceiling, so a mass-slashing incident cannot flood either. Reorgs get a deliberately generous budget of their own — the orphaned branch is unobtainable anywhere else, and reorgs are self-limiting per slot, but that is not a bound in aggregate: an equivocation storm, or an agent inserting many distinct roots per slot, would otherwise be unbounded corpus spend. Skips are labelled `rate_capped_common` / `rate_capped_rare` / `rate_capped_reorg`.

The window is tumbling, not sliding: it bounds sustained volume, not instantaneous burstiness. A cap of `0` promotes nothing in that tier — to drop a class of captures, disable its trigger instead.

## Devnet recreation

The service's own reason for existing is that devnets are torn down and recreated under the same name, so it cannot treat a network name as a stable identity. Per-network state (cursor, genesis validators root, rate window, retry) lives in one resettable value with two detectors:

- **Height regression** — the new chain restarts at slot 0, so once the reaper clears the old one the target epoch drops below the forward-only cursor. That resets the cursor and rescans the retained window, which is safe precisely because the regression proves the old chain is gone: the reaper is time-based, so if its newest rows are gone, all of them are.
- **Identity change** — the GVR is re-resolved on a 15m TTL from the *newest* retained state, the one that says what the name means now. On a change the identity is cleared and the backlog between cursor and target is **skipped, not rescanned**: that backlog may still contain the old chain, and block-only promotions take their network id from the cache, so rescanning it would file the old chain's blocks under the new chain's name. The height regression then rescans what actually remains. Losing a bounded window beats mislabelling the corpus.

The rate window deliberately survives a reset — otherwise repeated resets would be a way around the flood guard. Both events are counted by `network_resets_total{reason}`.

## Failure handling

- A failed promotion holds its epoch back for retry next tick (the existence probe makes re-processing free), bounded to `maxEpochAttempts = 10` before the epoch is abandoned with an error log and metric, so a deterministic poison candidate cannot wedge a network's progress.
- One tick processes at most `maxEpochsPerTick = 64` epochs per network; the backlog drains over subsequent ticks instead of turning a cold start into one unbounded run of queries.
- The head epoch is cross-checked against the head slot and the configured spec before it becomes the target. The epoch column is agent-computed, so one mis-indexed row could otherwise drag the cursor into epochs that will never exist; an implausible value is clamped, logged at error, and counted as `implausible_head_epoch`.
- A truncated epoch listing (`epochRowLimit`) is reported rather than looking like a short epoch.
- `Stop` waits for an in-flight tick, bounded by `stopTimeout` and by its context, and returns immediately when the loop was never started — the server passes a context that shutdown does not cancel, so an unbounded wait there would hang the process past its own signal handler.

## Deviations from the spec, deliberate

1. **Cadence is index-driven, not wallclock-driven.** The server has no beacon connection (no genesis/spec source), so the head is `max(epoch)` in the index per network — the epoch column is agent-computed and therefore respects the real network spec. `slotsPerEpoch`/`secondsPerSlot` live in the promotion config, used for the retention check, the head-epoch sanity check, and manifests.
2. **`context.finalized_epoch_at_promotion` / `finalizing` are absent.** Finality is not observable server-side; omitted rather than fabricated. `context.head_slot_at_promotion` is recorded.
3. **Structurally identical forks report the older name** (fulu blocks decode as electra). Trigger evaluation is identical either way; the electra->fulu `fork_boundary` is invisible until the library pin distinguishes them.

## Plumbing

- `store.Store` gained one method, `SaveRaw`, implemented for S3 and FS — the corpus writer needs plain puts at caller-chosen keys. Note this is a breaking change for any out-of-repo implementer of the exported interface; only `fs` and `s3` exist in-tree.
- Store metrics are now one instance per namespace. They were a single process-wide instance, so a second store's activity was attributed to whichever store was constructed first — i.e. corpus writes would have landed on the buffer's counters.
- `beacon_blocks` and `beacon_states` gain a `(network, epoch)` index. `epoch` was the only column the promotion service filters on that was unindexed, making every per-epoch listing a full table scan. Picked up by AutoMigrate.
- New `services.promotion` config block (see `example_server_config.yaml`); wired in `service.CreateGRPCServices` next to indexer/api, which now also receives the buffer store config for the distinct-store check.

## Testing

Unit suite pins every semantic in the spec's checklist: pairing across skipped slots, parent-vs-child `state_root` off-by-one trap, digests over decompressed bytes with byte-identical corpus objects, both-branches reorg promotion with non-colliding ids and canonical/orphaned labels, restart idempotency (zero new objects, zero rewrites), the three-tier budget (rare beats a common flood, each tier's ceiling holds, rescans preserve budget, a failed write consumes none), bounded retry and abandonment, startup retention and distinct-store refusal, undecodable-fork promotion, unpaired promotion on missing parent state, GVR-mismatch refusal, baseline determinism under an unloadable block, trigger toggles, path-traversal sanitisation, the shutdown lifecycle, and the Appendix A byte-peek sanity rules.

Devnet-recreation handling is covered directly: height-regression reset, identity-change backlog skip, implausible head epoch, and the per-tick bound. Each behavioural test was confirmed to fail with its fix reverted.

`go build ./...`, `go vet ./...`, `go test ./...` (plus `-race` on the changed packages), and `golangci-lint run` are clean.

Spec §10.1 `[VERIFY]` is resolved in code review: `Indexer.CreateBeaconBlock` dedupes on `(slot, block_root, node)` and `persistence.InsertBeaconBlock` is a plain `Create` with no upsert/OnConflict, so a post-reorg re-capture with a different root creates a new row and the orphan's row survives. I10 holds without indexer changes; the unit suite also exercises same-slot different-root coexistence end to end.

## Live acceptance

A full local run (kurtosis devnet + minio corpus) verified the lifecycle — healthy chain: epochs judged, zero promotions; 50% validators stopped: finality froze, `gap`/`low_participation` captures flowed (200 promoted, 556 visibly rate-capped); validators restored: finality recovered and both captures *and* skips went flat while processing continued. Manifest claims (`expected_state_root`, pairing across skipped slots, content addressing, GVR) verified against the beacon node as an independent oracle.

## Remaining validation before/while merging

- [ ] Re-run live acceptance (spec §8) on the current head: devnet + assertoor slashing test, verify both reorg branches land and a sample verifies `hash_tree_root(state) == expected_state_root`; round-trip a handful of pairs through the beaconfuzz corpus tooling.
- [ ] Exercise the recreate path live: tear the devnet down mid-run and confirm the corpus picks the new chain up under a new `network` prefix rather than going quiet.
